### PR TITLE
Replace Jade with Pug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ node_modules
 jspm_packages
 coverage
 npm-debug.log
+.idea
 
 dist

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![Build Status](https://travis-ci.org/Polyconseil/easygettext.svg?branch=master)](https://travis-ci.org/Polyconseil/easygettext)
 [![codecov.io](https://codecov.io/github/Polyconseil/easygettext/coverage.svg?branch=master)](https://codecov.io/github/Polyconseil/easygettext?branch=master)
 
-Simple gettext tokens extraction tools for HTML and Jade files. Also converts from PO to JSON.
+Simple gettext tokens extraction tools for HTML and Jade/Pug files. Also converts from PO to JSON.
 
 ### Motivation
 
 [angular-gettext](https://angular-gettext.rocketeer.be/) is a very neat tool, that comes with Grunt tooling
-to extract translation tokens from your Jade/HTML templates and JavaScript code.
+to extract translation tokens from your Jade/Pug/HTML templates and JavaScript code.
 
 Unfortunately, this has two drawbacks:
 

--- a/src/extract-cli.js
+++ b/src/extract-cli.js
@@ -9,7 +9,7 @@ import minimist from 'minimist';
 import {Extractor} from './extract.js';
 
 const PROGRAM_NAME = 'easygettext';
-const ALLOWED_EXTENSIONS = ['html', 'htm', 'jade'];
+const ALLOWED_EXTENSIONS = ['html', 'htm', 'jade', 'pug'];
 
 // Process arguments
 const argv = minimist(process.argv.slice(2));
@@ -34,8 +34,8 @@ files.forEach(function(filename) {
   console.log(`[${PROGRAM_NAME}] extracting: '${filename}`);
   try {
     let data = fs.readFileSync(file, {encoding: 'utf-8'}).toString();
-    if (ext === 'jade') {
-      file = file.replace(/\.jade$/, '.html');
+    if (ext === 'jade' || ext === 'pug') {
+      file = file.replace(/\.(jade|pug)$/, '.html');
       // Add empty require function to the context to avoid errors with webpack require inside jade
       data = jade.render(data, {pretty: true, require: function(){}});
     }


### PR DESCRIPTION
That's it. The JADE itself can't be replaced with Pug as it is in beta state (they want to release 2.0.0 soon) and package version 1.11 still has name Jade.