### PR TITLE
Add v-translate to the default attributes list

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,7 @@
 export const DEFAULT_ATTRIBUTES = [
-  'translate',
   'i18n',
+  'translate',
+  'v-translate',
 ];
 
 export const ATTRIBUTE_COMMENT = 'comment';


### PR DESCRIPTION
This will allow easygettext to work with the Vue.js v-translate directive