### PR TITLE
Meaningful names for new delimiters parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,12 @@ It recognizes the following token flavours (currently; feel free to extend it!)
 <div translate translate-comment="My comment...">Hello World</div>
 <div translate translate-plural="Hello worlds">Hello World</div>
 <div placeholder="{{ 'Hello World' | translate }}"></div>
-<div placeholder="'Hello World' | translate"></div>
 <div placeholder="{{ scopeVariable || ('Hello World' | translate) }}"></div>
 <get-text>Hello World</get-text>
 <i18n>Hello World</i18n>
 <translate>Hello World</translate>
+<!--  The default delimiters '{{' and '}}' must be changed to empty strings to handle this example -->
+<div placeholder="'Hello World' | translate"></div>
 ```
 
 You can combine any context, comment and plural together. Also, you can use 'i18n' instead
@@ -67,7 +68,7 @@ gettext-extract --attribute v-translate --output dictionary.pot foo.html bar.jad
 
 gettext-extract --attribute v-translate --attribute v-i18n --output dictionary.pot foo.html bar.jade
 
-gettext-extract --startDelim '[#' --endDelim '#]' --output dictionary.pot foo.html bar.jade
+gettext-extract --startDelimiter '[#' --endDelimiter '#]' --output dictionary.pot foo.html bar.jade
 ```
 
 ##### gettext-compile

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,10 +4,10 @@ export const DEFAULT_ATTRIBUTES = [
   'translate',
 ];
 
-export const DEFAULT_DELIM = {
-	start: '{{',
-	end: '}}'
-}
+export const DEFAULT_DELIMITERS = {
+  start: '{{',
+  end: '}}',
+};
 
 export const ATTRIBUTE_COMMENT = 'comment';
 export const ATTRIBUTE_CONTEXT = 'context';

--- a/src/extract-cli.js
+++ b/src/extract-cli.js
@@ -17,8 +17,8 @@ const argv = minimist(process.argv.slice(2));
 const files = argv._.sort() || [];
 const quietMode = argv.quiet || false;
 const outputFile = argv.output || null;
-const startDelim = argv.startDelim === undefined ? constants.DEFAULT_DELIM.start : argv.startDelim;
-const endDelim = argv.endDelim === undefined ? constants.DEFAULT_DELIM.end : argv.endDelim;
+const startDelimiter = argv.startDelimiter === undefined ? constants.DEFAULT_DELIMITERS.start : argv.startDelimiter;
+const endDelimiter = argv.endDelimiter === undefined ? constants.DEFAULT_DELIMITERS.end : argv.endDelimiter;
 // Allow to pass extra attributes, e.g. gettext-extract --attribute v-translate --attribute v-i18n
 const extraAttribute = argv.attribute || false;
 
@@ -40,8 +40,8 @@ if (extraAttribute) {
 const extractor = new Extractor({
   lineNumbers: true,
   attributes,
-  startDelim,
-  endDelim
+  startDelimiter,
+  endDelimiter,
 });
 
 files.forEach(function(filename) {

--- a/src/extract.js
+++ b/src/extract.js
@@ -72,8 +72,8 @@ export class Extractor {
 
   constructor(options) {
     this.options = Object.assign({
-      startDelim: '{{',
-      endDelim: '}}',
+      startDelimiter: '{{',
+      endDelimiter: '}}',
       attributes: constants.DEFAULT_ATTRIBUTES,
       lineNumbers: false,
     }, options);
@@ -89,10 +89,10 @@ export class Extractor {
      */
     this.items = {};
     this.filterRegexps = this.options.attributes.map((attribute) => {
-      const startOrEndQuotes = `(?:\\&quot;|[\\'"])`  // matches simple / double / HTML quotes
-      const spacesOrPipeChar = `\\s*\\|\\s*`        // matches the pipe string of the filter
-      const start = this.options.startDelim.replace(ESCAPE_REGEX, '\\$&');
-      const end = this.options.endDelim.replace(ESCAPE_REGEX, '\\$&');
+      const startOrEndQuotes = `(?:\\&quot;|[\\'"])`;  // matches simple / double / HTML quotes
+      const spacesOrPipeChar = `\\s*\\|\\s*`;        // matches the pipe string of the filter
+      const start = this.options.startDelimiter.replace(ESCAPE_REGEX, '\\$&');
+      const end = this.options.endDelimiter.replace(ESCAPE_REGEX, '\\$&');
       return new RegExp(`${start}.*${startOrEndQuotes}(.*)${startOrEndQuotes}${spacesOrPipeChar}${attribute}.*${end}`);
     });
   }

--- a/src/extract.spec.js
+++ b/src/extract.spec.js
@@ -119,8 +119,8 @@ describe('Raw translation data', () => {
     expect(data3[0].text).to.equal('So long, my dear');
 
     const extractorWithParams = new Extractor({
-      startDelim: '',
-      endDelim: '',
+      startDelimiter: '',
+      endDelimiter: '',
     });
     const data4 = extractorWithParams._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML3_FILTER4);
     expect(data4.length).to.equal(1);


### PR DESCRIPTION
- Rename (start|end)Delim to (start|end)Delimiter
- DEFAULT_DELIMITERS
- Fix a few eslint warnings
- Add comment about a special case provided as example in README