### PR TITLE
Upgrade from Jade to Pug

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,12 @@ It recognizes the following token flavours (currently; feel free to extend it!)
 <div translate translate-comment="My comment...">Hello World</div>
 <div translate translate-plural="Hello worlds">Hello World</div>
 <div placeholder="{{ 'Hello World' | translate }}"></div>
-<div placeholder="'Hello World' | translate"></div>
 <div placeholder="{{ scopeVariable || ('Hello World' | translate) }}"></div>
 <get-text>Hello World</get-text>
 <i18n>Hello World</i18n>
 <translate>Hello World</translate>
+<!--  The default delimiters '{{' and '}}' must be changed to empty strings to handle this example -->
+<div placeholder="'Hello World' | translate"></div>
 ```
 
 You can combine any context, comment and plural together. Also, you can use 'i18n' instead
@@ -67,7 +68,7 @@ gettext-extract --attribute v-translate --output dictionary.pot foo.html bar.jad
 
 gettext-extract --attribute v-translate --attribute v-i18n --output dictionary.pot foo.html bar.jade
 
-gettext-extract --startDelim '[#' --endDelim '#]' --output dictionary.pot foo.html bar.jade
+gettext-extract --startDelimiter '[#' --endDelimiter '#]' --output dictionary.pot foo.html bar.jade
 ```
 
 ##### gettext-compile

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![Build Status](https://travis-ci.org/Polyconseil/easygettext.svg?branch=master)](https://travis-ci.org/Polyconseil/easygettext)
 [![codecov.io](https://codecov.io/github/Polyconseil/easygettext/coverage.svg?branch=master)](https://codecov.io/github/Polyconseil/easygettext?branch=master)
 
-Simple gettext tokens extraction tools for HTML and Jade files. Also converts from PO to JSON.
+Simple gettext tokens extraction tools for HTML and Pug files. Also converts from PO to JSON.
 
 ### Motivation
 
 [angular-gettext](https://angular-gettext.rocketeer.be/) is a very neat tool, that comes with Grunt tooling
-to extract translation tokens from your Jade/HTML templates and JavaScript code.
+to extract translation tokens from your Pug/Jade/HTML templates and JavaScript code.
 
 Unfortunately, this has two drawbacks:
 
@@ -39,7 +39,7 @@ Simply invoke the tool on the templates you want to extract a POT dictionary tem
 The optional '--ouput' argument enables you to directly output to a file.
 
 ```
-gettext-extract --output dictionary.pot foo.html bar.jade
+gettext-extract --output dictionary.pot foo.html bar.pug
 ```
 
 It recognizes the following token flavours (currently; feel free to extend it!)

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   "dependencies": {
     "cheerio": "^0.19.0",
     "fs": "0.0.2",
-    "jade": "^1.11.0",
     "minimist": "^1.2.0",
-    "pofile": "^1.0.2"
+    "pofile": "^1.0.2",
+    "pug": "^2.0.0-rc.4"
   },
   "files": [
     "src",

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,10 +4,10 @@ export const DEFAULT_ATTRIBUTES = [
   'translate',
 ];
 
-export const DEFAULT_DELIM = {
-	start: '{{',
-	end: '}}'
-}
+export const DEFAULT_DELIMITERS = {
+  start: '{{',
+  end: '}}',
+};
 
 export const ATTRIBUTE_COMMENT = 'comment';
 export const ATTRIBUTE_CONTEXT = 'context';

--- a/src/extract-cli.js
+++ b/src/extract-cli.js
@@ -17,8 +17,8 @@ const argv = minimist(process.argv.slice(2));
 const files = argv._.sort() || [];
 const quietMode = argv.quiet || false;
 const outputFile = argv.output || null;
-const startDelim = argv.startDelim === undefined ? constants.DEFAULT_DELIM.start : argv.startDelim;
-const endDelim = argv.endDelim === undefined ? constants.DEFAULT_DELIM.end : argv.endDelim;
+const startDelimiter = argv.startDelimiter === undefined ? constants.DEFAULT_DELIMITERS.start : argv.startDelimiter;
+const endDelimiter = argv.endDelimiter === undefined ? constants.DEFAULT_DELIMITERS.end : argv.endDelimiter;
 // Allow to pass extra attributes, e.g. gettext-extract --attribute v-translate --attribute v-i18n
 const extraAttribute = argv.attribute || false;
 
@@ -40,8 +40,8 @@ if (extraAttribute) {
 const extractor = new Extractor({
   lineNumbers: true,
   attributes,
-  startDelim,
-  endDelim
+  startDelimiter,
+  endDelimiter,
 });
 
 files.forEach(function(filename) {

--- a/src/extract-cli.js
+++ b/src/extract-cli.js
@@ -67,7 +67,7 @@ files.forEach(function(filename) {
   }
 });
 if (outputFile) {
-  fs.writeFile(outputFile, extractor.toString());
+  fs.writeFileSync(outputFile, extractor.toString());
 } else {
   console.log(extractor.toString());
 }

--- a/src/extract-cli.js
+++ b/src/extract-cli.js
@@ -3,7 +3,7 @@
 /* eslint no-console:0 */
 
 import fs from 'fs';
-import jade from 'jade';
+import pug from 'pug';
 import minimist from 'minimist';
 
 import * as constants from './constants.js';
@@ -56,8 +56,8 @@ files.forEach(function(filename) {
     let data = fs.readFileSync(file, {encoding: 'utf-8'}).toString();
     if (['jade', 'pug'].indexOf(ext) !== -1) {
       file = file.replace(/\.(jade|pug)$/, '.html');
-      // Add empty require function to the context to avoid errors with webpack require inside jade
-      data = jade.render(data, { filename: file, pretty: true, require: function() {}});
+      // Add empty require function to the context to avoid errors with webpack require inside pug
+      data = pug.render(data, { filename: file, pretty: true, require: function() {}});
     }
     extractor.parse(file, data);
   } catch (e) {

--- a/src/extract-cli.js
+++ b/src/extract-cli.js
@@ -27,12 +27,12 @@ if (!quietMode && (!files || files.length === 0)) {
   process.exit(1);
 }
 
-let attributes = constants.DEFAULT_ATTRIBUTES.slice()
+let attributes = constants.DEFAULT_ATTRIBUTES.slice();
 if (extraAttribute) {
   if (typeof extraAttribute === 'string') {  // Only one extra attribute was passed.
-    attributes.push(extraAttribute)
+    attributes.push(extraAttribute);
   } else {  // Multiple extra attributes were passed.
-    attributes = attributes.concat(extraAttribute)
+    attributes = attributes.concat(extraAttribute);
   }
 }
 
@@ -57,7 +57,7 @@ files.forEach(function(filename) {
     if (['jade', 'pug'].indexOf(ext) !== -1) {
       file = file.replace(/\.(jade|pug)$/, '.html');
       // Add empty require function to the context to avoid errors with webpack require inside jade
-      data = jade.render(data, { filename: file, pretty: true, require: function(){}});
+      data = jade.render(data, { filename: file, pretty: true, require: function() {}});
     }
     extractor.parse(file, data);
   } catch (e) {

--- a/src/extract.js
+++ b/src/extract.js
@@ -72,8 +72,8 @@ export class Extractor {
 
   constructor(options) {
     this.options = Object.assign({
-      startDelim: '{{',
-      endDelim: '}}',
+      startDelimiter: '{{',
+      endDelimiter: '}}',
       attributes: constants.DEFAULT_ATTRIBUTES,
       lineNumbers: false,
     }, options);
@@ -89,10 +89,10 @@ export class Extractor {
      */
     this.items = {};
     this.filterRegexps = this.options.attributes.map((attribute) => {
-      const startOrEndQuotes = `(?:\\&quot;|[\\'"])`  // matches simple / double / HTML quotes
-      const spacesOrPipeChar = `\\s*\\|\\s*`        // matches the pipe string of the filter
-      const start = this.options.startDelim.replace(ESCAPE_REGEX, '\\$&');
-      const end = this.options.endDelim.replace(ESCAPE_REGEX, '\\$&');
+      const startOrEndQuotes = `(?:\\&quot;|[\\'"])`;  // matches simple / double / HTML quotes
+      const spacesOrPipeChar = `\\s*\\|\\s*`;        // matches the pipe string of the filter
+      const start = this.options.startDelimiter.replace(ESCAPE_REGEX, '\\$&');
+      const end = this.options.endDelimiter.replace(ESCAPE_REGEX, '\\$&');
       return new RegExp(`${start}.*${startOrEndQuotes}(.*)${startOrEndQuotes}${spacesOrPipeChar}${attribute}.*${end}`);
     });
   }

--- a/src/extract.spec.js
+++ b/src/extract.spec.js
@@ -119,8 +119,8 @@ describe('Raw translation data', () => {
     expect(data3[0].text).to.equal('So long, my dear');
 
     const extractorWithParams = new Extractor({
-      startDelim: '',
-      endDelim: '',
+      startDelimiter: '',
+      endDelimiter: '',
     });
     const data4 = extractorWithParams._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML3_FILTER4);
     expect(data4.length).to.equal(1);


### PR DESCRIPTION
The project Jade is now called Pug. The new compiler is slightly different (https://pugjs.org/api/migration-v2.html) but I think the changes are for the best.

The last commit fixes a node warning about async callback....