### PR TITLE
Made filter-regexp more robust

### DIFF
--- a/src/extract.js
+++ b/src/extract.js
@@ -93,7 +93,7 @@ export class Extractor {
       const spacesOrPipeChar = `\\s*\\|\\s*`;        // matches the pipe string of the filter
       const start = this.options.startDelimiter.replace(ESCAPE_REGEX, '\\$&');
       const end = this.options.endDelimiter.replace(ESCAPE_REGEX, '\\$&');
-      return new RegExp(`${start}.*${startOrEndQuotes}(.*)${startOrEndQuotes}${spacesOrPipeChar}${attribute}.*${end}`);
+      return new RegExp(`${start}[^'"]*${startOrEndQuotes}(.*)${startOrEndQuotes}${spacesOrPipeChar}${attribute}\\s*${end}`);
     });
   }
 

--- a/src/extract.spec.js
+++ b/src/extract.spec.js
@@ -125,5 +125,21 @@ describe('Raw translation data', () => {
     const data4 = extractorWithParams._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML3_FILTER4);
     expect(data4.length).to.equal(1);
     expect(data4[0].text).to.equal('So long, my dear');
+
+    const data5 = extractor._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML3_FILTER5);
+    expect(data5.length).to.equal(1);
+    expect(data5[0].text).to.equal('Guns\'n roses, my dear');
+
+    const data6 = extractorWithParams._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML3_FILTER6);
+    expect(data6.length).to.equal(1);
+    expect(data6[0].text).to.equal('Guns\'n roses, my dear');
+
+    const extractorWithBindOnce = new Extractor({
+      startDelimiter: '::',
+      endDelimiter: '',
+    });
+    const data7 = extractorWithBindOnce._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML3_FILTER7);
+    expect(data7.length).to.equal(1);
+    expect(data7[0].text).to.equal('Guns\'n roses, my dear');
   });
 });

--- a/src/test-fixtures.js
+++ b/src/test-fixtures.js
@@ -19,6 +19,9 @@ export const HTML3_FILTER1 =  "<h2 tooltip=\"{{'Hola, mujer'|i18n}}\">StufStuff<
 export const HTML3_FILTER2 =  "<h2 tooltip=\"{{ a || 'Hola, hola'|i18n }}\">StufStuff</h2>";
 export const HTML3_FILTER3 =  "<h2 attr=\"{{ &quot;So long, my dear' |i18n }}\">Martha</h2>";
 export const HTML3_FILTER4 =  "<h2 attr=\"&quot;So long, my dear' |i18n\">Martha</h2>";
+export const HTML3_FILTER5 =  "<h2 attr=\"{{ 'Guns\'n roses, my dear' |i18n }}\">Martha</h2>";
+export const HTML3_FILTER6 =  "<h2 attr=\"'Guns\'n roses, my dear' |i18n \">Martha</h2>";
+export const HTML3_FILTER7 =  "<h2 attr=\"::'Guns\'n roses, my dear' |i18n \">Martha</h2>";
 
 export const HTML4_TAG0 =  '<translate>Duck</translate>';
 export const HTML4_TAG1 =  '<i18n>Dice</i18n>';


### PR DESCRIPTION
Can you please merge this change and release a new NPM package?

Got error when extracting messages like `ng-bind="::'Your users' activity level.' | translate"`.
Before the change the result was: ` activity level.`
After the change the result is: `Your users' activity level.`
