### PR TITLE
Some major changes to support complex nested structures, multiple translation filters (even outside tags), and joining “split strings”

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# Please see http://EditorConfig.org for info on EditorConfig.
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.js]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Unfortunately, this has two drawbacks:
 
 This library comes up with two simple CLI tools to extract and compile your HTML tokens.
 
-### Why this library?
+### Why This Library?
 
 Our frontend toolchain, [systematic](https://github.com/Polyconseil/systematic) doesn't rely on Grunt/Gulp/Broccoli/...
 and uses a combination of simple Makefiles and CLI tools to do the job.
@@ -26,9 +26,18 @@ The toolchain being framework-agnostic, we don't want to depend on Angular to ex
 On another note, we use the standard [xgettext](http://www.gnu.org/savannah-checkouts/gnu/gettext/manual/html_node/xgettext-Invocation.html)
 tool to extract our JavaScript translation tokens.
 
-Nevertheless, the way [angular-gettext] does it (with tokens, directly in HTML) is elegant, is used by many other
+Nevertheless, the way [angular-gettext](https://angular-gettext.rocketeer.be/) does it (with tokens, directly in HTML) is elegant, is used by many other
 libraries and will also be the way to do it in Angular2.
 
+### Installation
+You can install the [easygettext](https://www.npmjs.com/package/easygettext) package by running 
+```bash
+npm install --dev easygettext
+```
+or 
+```bash
+yarn add --save-dev easygettext
+```
 
 
 ### Usage & Examples
@@ -54,7 +63,15 @@ It recognizes the following token flavours (currently; feel free to extend it!)
 <get-text>Hello World</get-text>
 <i18n>Hello World</i18n>
 <translate>Hello World</translate>
-<!--  The default delimiters '{{' and '}}' must be changed to empty strings to handle this example -->
+<!--  The following becomes 'Broken strings are joined'  --> 
+<span ng-bind="{{ 'Broken '
+ + 'strings ' +
+ 'are ' + 
+ 'joined' |translate}}"></span>
+<!--  By supplying the  --filterPrefix '::' parameter  -->  
+<span>{{:: 'Something …' |translate}}</span>
+<!--  The default delimiters '{{' and '}}' must be changed to empty strings to handle these examples  -->
+<span ng-bind=":: 'Something …' |translate"></span>
 <div placeholder="'Hello World' | translate"></div>
 ```
 
@@ -63,7 +80,7 @@ of 'translate' as master token.
 
 You can also provide your own master tokens:
 
-```
+```bash
 gettext-extract --attribute v-translate --output dictionary.pot foo.html bar.jade
 
 gettext-extract --attribute v-translate --attribute v-i18n --output dictionary.pot foo.html bar.jade
@@ -75,21 +92,81 @@ gettext-extract --startDelimiter '[#' --endDelimiter '#]' --output dictionary.po
 
 Outputs or writes to an output file, the sanitized JSON version of a PO file.
 
-```
+```bash
 gettext-compile --output translations.json fr.po en.po de.po
 ```
+
+### AngularJS
+If you use `easygettext` to extract files from an AngularJS code base, you might find the following tips helpful.
+
+To cover the cases (1)
+```html
+<input placeholder="{{:: 'Insert name …' |translate }}">
+<input placeholder="{{ 'Insert name …' |translate }}">
+```
+
+and (2)
+```html
+<a href="#" ng-bind=":: 'Link text' |translate"></a>
+<a href="#" ng-bind="'Link text' |translate"></a>
+<a href="#">{{::'Link text' |translate}}</a>
+<a href="#">{{'Link text' |translate}}</a>
+``` 
+you should run the extraction tool twice.  Once with the command-line arguments
+```bash
+--startDelimiter '{{' --endDelimiter '}}' --filterPrefix '::'
+```
+and once with the command-line arguments
+```bash
+--output ${html_b} --startDelimiter '' --endDelimiter '' --filterPrefix '::'
+```
+
+The following Bash script shows how `msgcat` might help
+```bash
+#!/usr/bin/env bash
+
+input_files="$(find ./src/ -iname \*\.html)"
+workdir=$(mktemp -d "${TMPDIR:-/tmp/}$(basename $0).XXXXXXXXXXXX") || exit 1
+
+html_a=${workdir}/messages-html-interpolate.pot
+html_b=${workdir}/messages-html.pot
+
+./dist/extract-cli.js --output ${html_a} --startDelimiter '{{' --endDelimiter '}}' --filterPrefix '::' ${input_files}
+./dist/extract-cli.js --output ${html_b} --startDelimiter '' --endDelimiter '' --filterPrefix '::' ${input_files}
+
+# Extract gettext “messages” from JavaScript files here, into ${es_a} …
+es_a=${workdir}/ecmascript.pot
+# [...] > ${es_a}
+
+# Merge the different catalog templates with `msgcat`:  
+merged_pot=${workdir}/merged.pot
+msgcat ${html_a} ${html_b} ${es_a} > ${merged_pot}
+
+# Cleanup, in case `msgcat` gave merge-conflicts in catalog header.
+header=${workdir}/header.pot
+sed -e '/^$/q' < ${html_a} > ${header}
+
+body=${workdir}/body.pot
+sed '1,/^$/d' < ${merged_pot} > ${body}
+
+cat ${header} ${body} > ${output_file}
+
+# Remove temporary directory with working files.
+rm -r ${workdir}
+``` 
+Please note that the script needs to be modified to match your needs and environment.
 
 ### Testing
 
 Run the tests using [mocha](https://mochajs.org/):
 
-```javascript
+```bash
 npm test
 ```
 
 We also have extensive coverage:
 
-```javascript
+```bash
 npm run cover
 ```
 
@@ -97,13 +174,13 @@ npm run cover
 
 Run:
 
-```javascript
+```bash
 npm run prepublish
 ```
 
 Then run `extract-cli.js`:
 
-```
+```bash
 ./dist/extract-cli.js --attribute v-translate --attribute v-i18n ~/output.html
 ```
 

--- a/package.json
+++ b/package.json
@@ -24,17 +24,17 @@
     "babel-core": "^6.2.1",
     "babel-plugin-transform-object-assign": "^6.1.18",
     "babel-preset-es2015": "^6.1.18",
-    "chai": "^3.4.1",
-    "eslint": "^1.10.1",
+    "chai": "^4.1.2",
+    "eslint": "^4.13.0",
     "isparta": "^4.0.0",
-    "mocha": "^2.3.4"
+    "mocha": "^4.0.1"
   },
   "bin": {
     "gettext-compile": "./dist/compile-cli.js",
     "gettext-extract": "./dist/extract-cli.js"
   },
   "dependencies": {
-    "cheerio": "^0.19.0",
+    "cheerio": "^0.22.0",
     "fs": "0.0.2",
     "minimist": "^1.2.0",
     "pofile": "^1.0.2",

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,6 +4,17 @@ export const DEFAULT_ATTRIBUTES = [
   'translate',
 ];
 
+export const DEFAULT_FILTERS = [
+  'i18n',
+  'translate',
+];
+
+export const DEFAULT_START_DELIMITER = '{{';
+export const DEFAULT_END_DELIMITER = '}}';
+
+// Could for example be '::', used by AngularJS to indicate one-time bindings.
+export const DEFAULT_FILTER_PREFIX = null;
+
 export const DEFAULT_DELIMITERS = {
   start: '{{',
   end: '}}',

--- a/src/extract.spec.js
+++ b/src/extract.spec.js
@@ -74,7 +74,9 @@ describe('Extractor object', () => {
 
 
 describe('Raw translation data', () => {
-  const extractor = new Extractor();
+  const extractor = new Extractor({
+    filterPrefix: '::'
+  });
 
   it('should extract data and metadata correctly', () => {
     const data = extractor._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML0_CTX0);
@@ -135,32 +137,279 @@ describe('Raw translation data', () => {
     expect(data6[0].text).to.equal('Guns\'n roses, my dear');
 
     const extractorWithBindOnce = new Extractor({
-      startDelimiter: '::',
+      startDelimiter: '',
       endDelimiter: '',
+      filterPrefix: '::',
     });
     const data7 = extractorWithBindOnce._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML3_FILTER7);
     expect(data7.length).to.equal(1);
     expect(data7[0].text).to.equal('Guns\'n roses, my dear');
   });
 
+  it('should handle complex nesting constructs with multiple interpolated filters', () => {
+    const extractorWithBindOnce = new Extractor({
+      filterPrefix: '::',
+    });
+
+    const data = extractorWithBindOnce._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML_COMPLEX_NESTING);
+    expect(data.length).to.equal(13);
+
+    expect(data[0].text).to.equal(
+      `<div translate="" translate-comment="Inner comment …" translate-context="Inner Context">
+    Before {{:: 'I18n before' |translate }}
+    <a href="#" aria-label="{{ 'Test link 1' |translate }}">
+      {{ 'Link part 1' |translate }}
+      {{:: 'Link part 2' |translate }}
+      {{ 'Link part 3' |translate }}</a>
+    Between {{:: 'I18n between' |translate }}
+    <a href="#" aria-label="{{ 'Test link 2' |translate }}">
+      {{ 'Reference part 1' |translate }}
+      {{:: 'Reference part 2' |translate }}
+      {{ 'Reference part 3' |translate }}</a>
+    After {{:: 'I18n after' |translate }}
+  </div>`);
+    expect(data[0].comment).to.equal('Outer comment …');
+    expect(data[0].context).to.equal('Outer Context');
+
+    expect(data[1].text).to.equal(
+      `Before {{:: 'I18n before' |translate }}
+    <a href="#" aria-label="{{ 'Test link 1' |translate }}">
+      {{ 'Link part 1' |translate }}
+      {{:: 'Link part 2' |translate }}
+      {{ 'Link part 3' |translate }}</a>
+    Between {{:: 'I18n between' |translate }}
+    <a href="#" aria-label="{{ 'Test link 2' |translate }}">
+      {{ 'Reference part 1' |translate }}
+      {{:: 'Reference part 2' |translate }}
+      {{ 'Reference part 3' |translate }}</a>
+    After {{:: 'I18n after' |translate }}`);
+    expect(data[1].comment).to.equal('Inner comment …');
+    expect(data[1].context).to.equal('Inner Context');
+
+    expect(data[2].text).to.equal(`I18n before`);
+    expect(data[2].context).to.equal(constants.MARKER_NO_CONTEXT);
+
+    expect(data[3].text).to.equal(`Test link 1`);
+    expect(data[3].context).to.equal(constants.MARKER_NO_CONTEXT);
+
+    expect(data[4].text).to.equal(`Link part 1`);
+    expect(data[4].context).to.equal(constants.MARKER_NO_CONTEXT);
+
+    expect(data[5].text).to.equal(`Link part 2`);
+    expect(data[5].context).to.equal(constants.MARKER_NO_CONTEXT);
+
+    expect(data[6].text).to.equal(`Link part 3`);
+    expect(data[6].context).to.equal(constants.MARKER_NO_CONTEXT);
+
+    expect(data[7].text).to.equal(`I18n between`);
+    expect(data[7].context).to.equal(constants.MARKER_NO_CONTEXT);
+
+    expect(data[8].text).to.equal(`Test link 2`);
+    expect(data[8].context).to.equal(constants.MARKER_NO_CONTEXT);
+
+    expect(data[9].text).to.equal(`Reference part 1`);
+    expect(data[9].context).to.equal(constants.MARKER_NO_CONTEXT);
+
+    expect(data[10].text).to.equal(`Reference part 2`);
+    expect(data[10].context).to.equal(constants.MARKER_NO_CONTEXT);
+
+    expect(data[11].text).to.equal(`Reference part 3`);
+    expect(data[11].context).to.equal(constants.MARKER_NO_CONTEXT);
+
+    expect(data[12].text).to.equal(`I18n after`);
+    expect(data[12].context).to.equal(constants.MARKER_NO_CONTEXT);
+  });
+
   it('should extract filters from nested constructs', () => {
     const extractorWithBindOnce = new Extractor({
-      startDelimiter: '::',
+      startDelimiter: '',
       endDelimiter: '',
+      filterPrefix: '::',
     });
 
-    const data8 = extractorWithBindOnce._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML_NESTED_FILTER);
-    expect(data8.length).to.equal(1);
-    expect(data8[0].text).to.equal('Votes <i class=\'fa fa-star\'></i>');
+    const data = extractorWithBindOnce._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML_NESTED_FILTER);
+    expect(data.length).to.equal(4);
+    expect(data[0].text).to.equal('Like');
+    expect(data[1].text).to.equal('Gets extracted now');
+    expect(data[2].text).to.equal('Number of votes');
+    expect(data[3].text).to.equal('Votes <i class=\'fa fa-star\'></i>');
+  });
 
-    const extractorWithInterpolateBindOnce = new Extractor({
-      startDelimiter: '{{::',
+  it('should extract filters that are broken across multiple lines', () => {
+    const extractorInterpolate = new Extractor({
+      startDelimiter: '{{',
       endDelimiter: '}}',
     });
-    const data9 = extractorWithInterpolateBindOnce._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML_NESTED_FILTER);
-    expect(data9.length).to.equal(3);
-    expect(data9[0].text).to.equal('Like');
-    expect(data9[1].text).to.equal('Gets extracted now');
-    expect(data9[2].text).to.equal('Number of votes');
+    const data = extractorInterpolate._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML_LINEBREAK_FILTER);
+    expect(data.length).to.equal(5);
+    expect(data[0].text).to.equal('Multi-line 0');
+    expect(data[1].text).to.equal('Multi-line 1');
+    expect(data[2].text).to.equal('Multi-line 2');
+    expect(data[3].text).to.equal('Multi-line 3');
+    expect(data[4].text).to.equal('Multi-line 4');
+  });
+
+  it('should extract filters from text before and after elements', () => {
+    const extractorInterpolate = new Extractor({
+      startDelimiter: '{{',
+      endDelimiter: '}}',
+    });
+    const data = extractorInterpolate._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML_TEXT_FILTER);
+    expect(data.length).to.equal(5);
+    expect(data[0].text).to.equal('Outside 0');
+    expect(data[1].text).to.equal('Text 0');
+    expect(data[2].text).to.equal('Between 0');
+    expect(data[3].text).to.equal('Text 3');
+    expect(data[4].text).to.equal('Outside 1');
+  });
+
+  it('should extract multiple filters from text blocks', () => {
+    const extractorInterpolate = new Extractor({
+      startDelimiter: '{{',
+      endDelimiter: '}}',
+    });
+    const data = extractorInterpolate._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML_TEXT_MULTIPLE_FILTER);
+    expect(data.length).to.equal(3);
+    expect(data[0].text).to.equal('Text 0');
+    expect(data[1].text).to.equal('Text 1');
+    expect(data[2].text).to.equal('Text 2');
+  });
+
+  it('should extract filters from text blocks with empty delimiters', () => {
+    const extractor = new Extractor({
+      startDelimiter: '',
+      endDelimiter: '',
+    });
+    const data = extractor._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML_TEXT_CHALLENGE);
+    expect(data.length).to.equal(3);
+    expect(data[0].text).to.equal('Thanks for joining ….  However, … does not start until');
+    expect(data[1].text).to.equal(', but will open');
+    expect(data[2].text).to.equal('minutes before that.');
+  });
+
+  it('should ignore comments and directives when extracting filters', () => {
+    const extractorInterpolate = new Extractor({
+      startDelimiter: '',
+      endDelimiter: '',
+      filterPrefix: '::',
+    });
+    const data = extractorInterpolate._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML_TEXT_FILTER_COMMENT);
+    expect(data.length).to.equal(1);
+    expect(data[0].text).to.equal('Text 1');
+  });
+
+  it('should join split strings', () => {
+    const extractorInterpolate = new Extractor({
+      startDelimiter: '',
+      endDelimiter: '',
+      filterPrefix: '::',
+    });
+    const data = extractorInterpolate._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML_FILTER_SPLIT_STRING);
+    expect(data.length).to.equal(1);
+    expect(data[0].text).to.equal('Three parts, one whole.');
+  });
+
+  it('should join strings split over multiple lines', () => {
+    const extractorInterpolate = new Extractor({
+      startDelimiter: '',
+      endDelimiter: '',
+      filterPrefix: '::',
+    });
+    const data0 = extractorInterpolate._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML_FILTER_SPLIT_MULTILINE_STRING_ATTR);
+    expect(data0.length).to.equal(1);
+    expect(data0[0].text).to.equal('Four parts, maybe, one whole.');
+
+    const data1 = extractorInterpolate._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML_FILTER_SPLIT_MULTILINE_STRING_INTERPOLATED);
+    expect(data1.length).to.equal(1);
+    expect(data1[0].text).to.equal('Four parts, probably, one whole.');
+  });
+
+  it('should extract translatable strings from commented nested filters', () => {
+    const extractorWithBindOnce = new Extractor({
+      startDelimiter: '',
+      endDelimiter: '',
+      filterPrefix: '::',
+    });
+
+    const data = extractorWithBindOnce._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML_COMMENTED_NESTED_FILTER);
+    expect(data.length).to.equal(4);
+    expect(data[0].text).to.equal('Like');
+    expect(data[1].text).to.equal('Gets extracted now');
+    expect(data[2].text).to.equal('Number of votes');
+    expect(data[3].text).to.equal('Votes <i class=\'fa fa-star\'></i>');
+  });
+
+  it('should extract strings from commented', () => {
+    const extractorWithBindOnce = new Extractor({
+      filterPrefix: '::',
+    });
+
+    const data = extractorWithBindOnce._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML_COMMENTED_COMPLEX_NESTING);
+    expect(data.length).to.equal(13);
+
+    expect(data[0].text).to.equal(
+      `<div translate="" translate-comment="Inner comment …" translate-context="Inner Context">
+    Before {{:: 'I18n before' |translate }}
+    <a href="#" aria-label="{{ 'Test link 1' |translate }}">
+      {{ 'Link part 1' |translate }}
+      {{:: 'Link part 2' |translate }}
+      {{ 'Link part 3' |translate }}</a>
+    Between {{:: 'I18n between' |translate }}
+    <a href="#" aria-label="{{ 'Test link 2' |translate }}">
+      {{ 'Reference part 1' |translate }}
+      {{:: 'Reference part 2' |translate }}
+      {{ 'Reference part 3' |translate }}</a>
+    After {{:: 'I18n after' |translate }}
+  </div>`);
+    expect(data[0].comment).to.equal('Outer comment …');
+    expect(data[0].context).to.equal('Outer Context');
+
+    expect(data[1].text).to.equal(
+      `Before {{:: 'I18n before' |translate }}
+    <a href="#" aria-label="{{ 'Test link 1' |translate }}">
+      {{ 'Link part 1' |translate }}
+      {{:: 'Link part 2' |translate }}
+      {{ 'Link part 3' |translate }}</a>
+    Between {{:: 'I18n between' |translate }}
+    <a href="#" aria-label="{{ 'Test link 2' |translate }}">
+      {{ 'Reference part 1' |translate }}
+      {{:: 'Reference part 2' |translate }}
+      {{ 'Reference part 3' |translate }}</a>
+    After {{:: 'I18n after' |translate }}`);
+    expect(data[1].comment).to.equal('Inner comment …');
+    expect(data[1].context).to.equal('Inner Context');
+
+    expect(data[2].text).to.equal(`I18n before`);
+    expect(data[2].context).to.equal(constants.MARKER_NO_CONTEXT);
+
+    expect(data[3].text).to.equal(`Test link 1`);
+    expect(data[3].context).to.equal(constants.MARKER_NO_CONTEXT);
+
+    expect(data[4].text).to.equal(`Link part 1`);
+    expect(data[4].context).to.equal(constants.MARKER_NO_CONTEXT);
+
+    expect(data[5].text).to.equal(`Link part 2`);
+    expect(data[5].context).to.equal(constants.MARKER_NO_CONTEXT);
+
+    expect(data[6].text).to.equal(`Link part 3`);
+    expect(data[6].context).to.equal(constants.MARKER_NO_CONTEXT);
+
+    expect(data[7].text).to.equal(`I18n between`);
+    expect(data[7].context).to.equal(constants.MARKER_NO_CONTEXT);
+
+    expect(data[8].text).to.equal(`Test link 2`);
+    expect(data[8].context).to.equal(constants.MARKER_NO_CONTEXT);
+
+    expect(data[9].text).to.equal(`Reference part 1`);
+    expect(data[9].context).to.equal(constants.MARKER_NO_CONTEXT);
+
+    expect(data[10].text).to.equal(`Reference part 2`);
+    expect(data[10].context).to.equal(constants.MARKER_NO_CONTEXT);
+
+    expect(data[11].text).to.equal(`Reference part 3`);
+    expect(data[11].context).to.equal(constants.MARKER_NO_CONTEXT);
+
+    expect(data[12].text).to.equal(`I18n after`);
+    expect(data[12].context).to.equal(constants.MARKER_NO_CONTEXT);
   });
 });

--- a/src/test-fixtures.js
+++ b/src/test-fixtures.js
@@ -3,25 +3,126 @@ export const FILENAME_1 = 'bar.htm';
 export const FILENAME_2 = 'baz.vue';
 
 
-export const HTML0_CTX0 =  `
+export const HTML0_CTX0 = `
 <div><h4 translate="translate" translate-context="For charlie">Hello world</h4></div>`;
-export const HTML0_CTX1 =  `
+export const HTML0_CTX1 = `
 <div><h4 translate="translate" translate-context="For jacques">Hello world</h4></div>`;
 
-export const HTML1_PLURAL0 =  '<h2 translate="" i18n-plural="We work">I work</h2>';
-export const HTML1_PLURAL1 =  '<h2 translate="" translate-plural="Us works">I work</h2>';
+export const HTML1_PLURAL0 = '<h2 translate="" i18n-plural="We work">I work</h2>';
+export const HTML1_PLURAL1 = '<h2 translate="" translate-plural="Us works">I work</h2>';
 
-export const HTML2_COMMENT0 =  '<h2 translate i18n-comment="My first comment">Hello</h2>';
-export const HTML2_COMMENT1 =  '<h2 translate="" translate-comment="Another comment">Hello</h2>';
+export const HTML2_COMMENT0 = '<h2 translate i18n-comment="My first comment">Hello</h2>';
+export const HTML2_COMMENT1 = '<h2 translate="" translate-comment="Another comment">Hello</h2>';
 
-export const HTML3_FILTER0 =  '<h2 translate-comment="Fugazy">{{ "Hola, hombre" | translate }}</h2>';
-export const HTML3_FILTER1 =  "<h2 tooltip=\"{{'Hola, mujer'|i18n}}\">StufStuff</h2>";
-export const HTML3_FILTER2 =  "<h2 tooltip=\"{{ a || 'Hola, hola'|i18n }}\">StufStuff</h2>";
-export const HTML3_FILTER3 =  "<h2 attr=\"{{ &quot;So long, my dear' |i18n }}\">Martha</h2>";
-export const HTML3_FILTER4 =  "<h2 attr=\"&quot;So long, my dear' |i18n\">Martha</h2>";
-export const HTML3_FILTER5 =  "<h2 attr=\"{{ 'Guns\'n roses, my dear' |i18n }}\">Martha</h2>";
-export const HTML3_FILTER6 =  "<h2 attr=\"'Guns\'n roses, my dear' |i18n \">Martha</h2>";
-export const HTML3_FILTER7 =  "<h2 attr=\"::'Guns\'n roses, my dear' |i18n \">Martha</h2>";
+export const HTML3_FILTER0 = `<h2 translate-comment="Fugazy">{{ "Hola, hombre" | translate }}</h2>`;
+export const HTML3_FILTER1 = `<h2 tooltip="{{'Hola, mujer'|i18n}}">StufStuff</h2>`;
+export const HTML3_FILTER2 = `<h2 tooltip="{{ a || 'Hola, hola'|i18n }}">StufStuff</h2>`;
+export const HTML3_FILTER3 = `<h2 attr="{{ &quot;So long, my dear&quot; |i18n }}">Martha</h2>`;
+export const HTML3_FILTER4 = `<h2 attr="&quot;So long, my dear&quot; |i18n">Martha</h2>`;
+export const HTML3_FILTER5 = `<h2 attr="{{ 'Guns'n roses, my dear' |i18n }}">Son</h2>`;
+export const HTML3_FILTER6 = `<h2 attr="'Guns'n roses, my dear' |i18n ">Daughter</h2>`;
+export const HTML3_FILTER7 = `<h2 attr="::'Guns'n roses, my dear' |i18n ">Wife</h2>`;
+
+export const HTML_FILTER_SPLIT_STRING = `
+<h2 ng-bind="::'Three' +' parts, '  +   'one whole.' |i18n ">Will be replaced</h2>
+`;
+
+export const HTML_FILTER_SPLIT_MULTILINE_STRING_ATTR = `
+<h2 ng-bind="::'Four' +
+ ' parts, ' +
+  'maybe, '
+  + 'one whole.' |i18n ">Will be replaced</h2>
+`;
+
+export const HTML_FILTER_SPLIT_MULTILINE_STRING_INTERPOLATED = `
+<h2>{{::'Four' +
+ ' parts, ' +
+  'probably, '
+  + 'one whole.' |i18n}}</h2>
+`;
+
+
+export const HTML_COMPLEX_NESTING = `<div translate translate-comment="Outer comment …"
+     translate-context="Outer Context">
+  <div translate translate-comment="Inner comment …"
+       translate-context="Inner Context">
+    Before {{:: 'I18n before' |translate }}
+    <a href="#" aria-label="{{ 'Test link 1' |translate }}">
+      {{ 'Link part 1' |translate }}
+      {{:: 'Link part 2' |translate }}
+      {{ 'Link part 3' |translate }}</a>
+    Between {{:: 'I18n between' |translate }}
+    <a href="#" aria-label="{{ 'Test link 2' |translate }}">
+      {{ 'Reference part 1' |translate }}
+      {{:: 'Reference part 2' |translate }}
+      {{ 'Reference part 3' |translate }}</a>
+    After {{:: 'I18n after' |translate }}
+  </div>
+</div>`;
+
+export const HTML_LINEBREAK_FILTER = `
+<div class="buttons">
+<a href="#"
+  ng-click="vm.doSomething()"
+  class="button">{{ 'Multi-line 0' |translate }}</a>
+  
+<a href="#"
+  ng-click="vm.doSomething()"
+  class="button">{{ 
+ 'Multi-line 1' |translate }}</a>
+
+<a href="#"
+  ng-click="vm.doSomething()"
+  class="button">{{ 'Multi-line 2'
+ |translate }}</a>
+
+<a href="#"
+  ng-click="vm.doSomething()"
+  class="button">{{'Multi-line 3' |
+ translate }}</a>
+
+<a href="#"
+  ng-click="vm.doSomething()"
+  class="button">{{ 'Multi-line 4' | translate 
+}}</a>
+`;
+
+export const HTML_TEXT_CHALLENGE = `
+<p>{{ 'Thanks for joining ….  However, … does not start until'
+  |translate }}
+  <span>{{ vm.startDatetime |amCalendar}}</span>{{ ', but will open' |
+  translate}}
+  {{ vm.roll_call_duration_minutes }}
+  {{ 'minutes before that.' |translate }}
+</p>
+`;
+
+export const HTML_TEXT_FILTER = `
+{{ 'Outside 0' |translate }}
+<div class="buttons">
+<a href="#">{{ 'Text 0' |translate }}</a>
+{{ 'Between 0' |translate }}
+<a href="#">{{ 'Text 3' |translate }}</a>
+</div>
+{{ 'Outside 1' |translate }}
+`;
+
+export const HTML_TEXT_MULTIPLE_FILTER = `
+<a href="#">
+{{ 'Text 0' |translate }} between
+ {{ 'Text 1' |translate }} between again
+ {{ 'Text 2' |translate }}
+</a>
+`;
+
+export const HTML_TEXT_FILTER_COMMENT = `
+<!doctype html>
+<a href="#">
+  <!-- First comment -->
+  {{:: 'Text 1' |translate }} between again
+  <!-- Second comment -->
+</a>
+`;
 
 export const HTML_NESTED_FILTER = `
   <li class="action thumbs-up"
@@ -31,12 +132,24 @@ export const HTML_NESTED_FILTER = `
   </li>
 `;
 
-export const HTML4_TAG0 =  '<translate>Duck</translate>';
-export const HTML4_TAG1 =  '<i18n>Dice</i18n>';
-export const HTML4_TAG2 =  '<get-text>Rabbit</get-text>';
-export const HTML4_TAG3 =  '<i18n translate>overtranslate</i18n>';
+export const HTML_COMMENTED_NESTED_FILTER = `
+<!--
+${HTML_NESTED_FILTER}
+-->
+`;
 
-export const HTML_LONG =  `
+export const HTML_COMMENTED_COMPLEX_NESTING = `
+<!--
+${HTML_COMPLEX_NESTING}
+-->
+`;
+
+export const HTML4_TAG0 = '<translate>Duck</translate>';
+export const HTML4_TAG1 = '<i18n>Dice</i18n>';
+export const HTML4_TAG2 = '<get-text>Rabbit</get-text>';
+export const HTML4_TAG3 = '<i18n translate>overtranslate</i18n>';
+
+export const HTML_LONG = `
   <div class="col-xs-4">
   <h4 translate="translate" translate-context="Pour maman">Hello world</h4>
   <h2 translate="" i18n-plural='We work'>I work</h2>
@@ -52,7 +165,7 @@ export const HTML_LONG =  `
   </tr>
 `;
 
-export const HTML_SORTING =  `
+export const HTML_SORTING = `
   <i18n>f</i18n>
   <i18n>0</i18n>
   <i18n>c</i18n>
@@ -182,7 +295,7 @@ msgid "Hello"
 msgstr ""
 `;
 
-export const POT_OUTPUT_SORTED= `msgid ""
+export const POT_OUTPUT_SORTED = `msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=utf-8\\n"
 "Content-Transfer-Encoding: 8bit\\n"


### PR DESCRIPTION
Hi, @vperron.

I appreciate that you let me submit code directly to the master repository now, but this pull request is quite extensive, so I want you to review it, if you want to, and then do the merge if you agree to these changes.

Some of the major code changes follow from the need to replace the `cheerio` `$('*').map(…)`-based traversal to one based on traversal of _all_ the nodes, even pure TEXT nodes.  However, I tried to stay true to the `map`, `filter`, and `reduce` way of structuring the code, and hope you like the new features.  At least, now the tool finally supports all that I need from it (for now).
