### PR TITLE
Add support for compiling strings from JavaScript expressions in filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ tool to extract our JavaScript translation tokens.
 Nevertheless, the way [angular-gettext](https://angular-gettext.rocketeer.be/) does it (with tokens, directly in HTML) is elegant, is used by many other
 libraries and will also be the way to do it in Angular2.
 
+Also, by utilizing [acorn](https://github.com/ternjs/acorn), this tool will parse and compile typical JavaScript expressions used in translate-filter expressions.  For example, exposed to a (AngularJS-based) fragment like 
+```html
+<span ng-bind="isNight ? 'Moon' + 'shine' : 'Day' + 'light' |translate"></span>
+<span ng-bind="isC ? 'C' + (isD ? 'D' : 'd') : 'c' + (isE ? 'E' : 'e') |i18n "></span>
+``` 
+will produce the following strings
+```text
+Moonshine
+Daylight
+CD
+Cd
+cE
+ce
+``` 
+Which will be correctly looked up and translated during runtime, at least by [angular-gettext](https://angular-gettext.rocketeer.be/). 
+
 ### Installation
 You can install the [easygettext](https://www.npmjs.com/package/easygettext) package by running 
 ```bash
@@ -68,6 +84,9 @@ It recognizes the following token flavours (currently; feel free to extend it!)
  + 'strings ' +
  'are ' + 
  'joined' |translate}}"></span>
+ <span ng-bind="'Bed n\'' + ' breakfast' |translate"></span>
+ <!-- JavaScript expressions are parsed and compiled -->
+<span ng-bind="true ? 'Always' : 'Never' |i18n "></span>
 <!--  By supplying the  --filterPrefix '::' parameter  -->  
 <span>{{:: 'Something …' |translate}}</span>
 <!--  The default delimiters '{{' and '}}' must be changed to empty strings to handle these examples  -->

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "gettext-extract": "./dist/extract-cli.js"
   },
   "dependencies": {
+    "acorn": "^5.2.1",
     "cheerio": "^0.22.0",
     "fs": "0.0.2",
     "minimist": "^1.2.0",

--- a/src/test-fixtures.js
+++ b/src/test-fixtures.js
@@ -19,12 +19,33 @@ export const HTML3_FILTER1 = `<h2 tooltip="{{'Hola, mujer'|i18n}}">StufStuff</h2
 export const HTML3_FILTER2 = `<h2 tooltip="{{ a || 'Hola, hola'|i18n }}">StufStuff</h2>`;
 export const HTML3_FILTER3 = `<h2 attr="{{ &quot;So long, my dear&quot; |i18n }}">Martha</h2>`;
 export const HTML3_FILTER4 = `<h2 attr="&quot;So long, my dear&quot; |i18n">Martha</h2>`;
-export const HTML3_FILTER5 = `<h2 attr="{{ 'Guns'n roses, my dear' |i18n }}">Son</h2>`;
-export const HTML3_FILTER6 = `<h2 attr="'Guns'n roses, my dear' |i18n ">Daughter</h2>`;
-export const HTML3_FILTER7 = `<h2 attr="::'Guns'n roses, my dear' |i18n ">Wife</h2>`;
+export const HTML3_FILTER5 = `<h2 attr="{{ 'Guns\\'n roses, my dear' |i18n }}">Son</h2>`;
+export const HTML3_FILTER6 = `<h2 attr="'Guns\\'n roses, my dear' |i18n ">Daughter</h2>`;
+export const HTML3_FILTER7 = `<h2 attr="::'Guns\\'n roses, my dear' |i18n ">Wife</h2>`;
 
 export const HTML_FILTER_SPLIT_STRING = `
 <h2 ng-bind="::'Three' +' parts, '  +   'one whole.' |i18n ">Will be replaced</h2>
+`;
+
+export const HTML_FILTER_ESCAPED_QUOTES = `
+{{ 'Life\\'s a tough teacher.' |translate}} 
+{{ "Life's a tough journey." |translate}}
+{{ "Life\\'s a tough road." |translate}}
+{{ "Life's a tough \\"boulevard\\"." |translate}}
+{{ 'Life\\'s a tough \\'journey\\'.' |translate}}
+`;
+
+export const HTML_VARIED_CHALLENGES = `
+<div aria-label="Message Selected Users">
+  <button type="button" 
+          ng-class="{'active': vm.messageView === 'preview', disabled: !vm.useHtml}"
+          ng-bind="vm.messageView !== 'preview' ? 'Preview' : 'Exit Preview' |translate"></button>
+  <div>
+    <button type="button" ng-bind="'Send Message' |translate" ></button>
+    <button type="button" ng-bind="'Reset' |translate" ></button>
+    <button type="button" ng-bind="'Cancel' |translate"></button>
+  </div>
+</div>
 `;
 
 export const HTML_FILTER_SPLIT_MULTILINE_STRING_ATTR = `
@@ -128,7 +149,7 @@ export const HTML_NESTED_FILTER = `
   <li class="action thumbs-up"
       title="{{::'Like' |translate}}" alt="{{::'Gets extracted now' |translate}}">
       <span ng-bind="::vm.voteCount |translate" alt="{{:: 'Number of votes' |translate}}"></span>
-      <span ng-bind-html="::'Votes <i class=\'fa fa-star\'></i>' |translate"></span>
+      <span ng-bind-html="::'Votes <i class=\\'fa fa-star\\'></i>' |translate"></span>
   </li>
 `;
 
@@ -148,6 +169,16 @@ export const HTML4_TAG0 = '<translate>Duck</translate>';
 export const HTML4_TAG1 = '<i18n>Dice</i18n>';
 export const HTML4_TAG2 = '<get-text>Rabbit</get-text>';
 export const HTML4_TAG3 = '<i18n translate>overtranslate</i18n>';
+export const HTML4_TAG4 = `<i18n translate>Life's a tough "journey"</i18n>`;
+export const HTML4_TAG5 = `<div attr="{{ 'Life\\'s a tough teacher' |translate}}"></div>`;
+export const HTML4_TAG6 = `
+<label class="btn btn-primary"
+       ng-class="{'active': vm.respectUsersPreferences}">
+  <input type="checkbox"
+         ng-model="vm.respectUsersPreferences"
+         autocomplete="off">{{'Respect Users\\' Preferences' | translate}}
+</label>
+`;
 
 export const HTML_LONG = `
   <div class="col-xs-4">
@@ -181,6 +212,33 @@ export const HTML_SORTING = `
   <i18n>aba</i18n>
   <i18n>2</i18n>
   <i18n>d</i18n>
+`;
+
+export const HTML_JS_EXPRESSION_COMPLEX_FILTERS = `
+<span ng-bind="'Bed n\\'' + ' breakfast' |translate"></span>
+<span ng-bind="true ? 'Always' : 'Never' |i18n "></span>
+<span ng-bind="'This will ' + (true ? 'always' : 'never') + ' be true' |i18n "></span>
+<span ng-bind="isNight ? 'Moon' + 'shine' : 'Day' + 'light' |translate"></span>
+<--! AB, Ab, a -->
+<span ng-bind="isATrue ? 'A' + (isBTrue ? 'B' : 'b') : 'a' |i18n "></span>
+<--! CD, Cd, cE, ce -->
+<span ng-bind="isC ? 'C' + (isD ? 'D' : 'd') : 'c' + (isE ? 'E' : 'e') |i18n "></span>
+`;
+
+export const HTML_JS_EXPRESSION_WITH_NUMBER = `
+{{ 'A' + 42 + '.' |translate }}
+`;
+
+export const HTML_JS_EXPRESSION_SYNTAX_ERROR = `
+{{ 'A' + b' |translate }}
+`;
+
+export const HTML_INCOMPLETE_COMMENT = `
+<!--ng-bind="'Cancel' |translate"></button>-->
+`;
+
+export const HTML_DELIMITERS_INSIDE_FILTER_TEXT = `
+<p ng-bind="'You received {{ vm.count}} coins!' |translate"></p>
 `;
 
 export const POT_OUTPUT_0 = `msgid ""
@@ -250,6 +308,26 @@ msgstr ""
 
 #: baz.vue
 msgid "Rabbit"
+msgstr ""
+`;
+
+export const POT_OUTPUT_QUOTES = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"Generated-By: easygettext\\n"
+"Project-Id-Version: \\n"
+
+#: foo.htm
+msgid "Life's a tough \\"journey\\""
+msgstr ""
+
+#: bar.htm
+msgid "Life's a tough teacher"
+msgstr ""
+
+#: baz.vue
+msgid "Respect Users' Preferences"
 msgstr ""
 `;
 
@@ -418,4 +496,3 @@ export const OUTPUT_DICT = {
     },
   },
 };
-


### PR DESCRIPTION
For example, presented with the fragment
`<span ng-bind="isNight ? 'Moon' + 'shine' : 'Day' + 'light' |translate"></span>`
the extractor will produce both `Moonshine` and `Daylight`.

Additionally, efforts have been made to make sure escaped quotes in the source
are handled correctly, so that the whole round-trip from extracting translatable strings
from the source through translating them into .po files and looking them up during
runtime works as expected, with strings like `'Five o\'clock'`.