### PR TITLE
Change fs.writeFile to fs.writeFileSync

### DIFF
--- a/src/compile-cli.js
+++ b/src/compile-cli.js
@@ -41,7 +41,7 @@ for (let file of files) {
 // Output results
 const translationString = JSON.stringify(translationData);
 if (outputFile) {
-  fs.writeFile(outputFile, translationString);
+  fs.writeFileSync(outputFile, translationString);
 } else {
   console.log(translationString);
 }


### PR DESCRIPTION
In commit https://github.com/Polyconseil/easygettext/pull/22/commits/5b7d41c9e3dfc84f62ab757dcb53f555cc3161f9 `src/extract-cli.js` got changed from `fs.writeFile` to `fs.writeFileSync` but not `src/compile-cli.js`. We upgraded node to v10 today and received an issue here. Is there any reason why this file didn't get changed?