### PR TITLE
Update acorn parser's ECMAScript version

### DIFF
--- a/src/javascript-extract.js
+++ b/src/javascript-extract.js
@@ -10,7 +10,7 @@ function getGettextTokensFromScript(script) {
   const extractedTokens = [];
 
   const ACORN_OPTIONS = {
-    ecmaVersion: 6,
+    ecmaVersion: 10,
     sourceType: 'module',
     locations: true,
     onToken: extractedTokens,

--- a/src/test-fixtures.js
+++ b/src/test-fixtures.js
@@ -254,7 +254,12 @@ exports.VUE_COMPONENT_WITH_SCRIPT_TAG = `
                     return this.$gettext("Hello there!")
                 },
                 duplicated_greeting_message() {
-                    return  this.$gettext("Hello there!")
+                    return this.$gettext("Hello there!")
+                }
+            },
+            methods: {
+                async getGreetingMessageAnswer() {
+                    return await Promise.resolve('General Kenobi!');
                 }
             }
         }
@@ -273,7 +278,12 @@ export default {
             return this.$gettext("Hello there!")
         },
         duplicated_greeting_message() {
-            return  this.$gettext("Hello there!")
+            return this.$gettext("Hello there!")
+        }
+    },
+    methods: {
+        async getGreetingMessageAnswer() {
+            return await Promise.resolve('General Kenobi!');
         }
     }
 }`;


### PR DESCRIPTION
Acorn parser ECMAVersion is too low and causes the parser to break on reserved keywords of the latest ECMAScript features like async/await.

How to test:
--------------
1. Set up a .vue file that uses modern javascript features like:

```html
    <template>
        <h1>{{ greeting_message }}</h1>
    </template>
    <script>
        export default {
            name: "greetings",
            computed: {
                greeting_message() {
                    return this.$gettext("Hello there!")
                },
                duplicated_greeting_message() {
                    return this.$gettext("Hello there!")
                }
            },
            methods: {
                async getGreetingMessageAnswer() {
                    return await Promise.resolve('General Kenobi!');
                }
            }
        }
     </script>
```
2. Run compile-cli.js with this file

Expected results:
--------------------

Strings are extracted whithout any parsing error due to the usage of async/await