### PR TITLE
Extract $ngettext strings from Vue.js <script> section

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ You can also extract the strings marked as translatable inside the <script> sect
 ```html
     <template>
         <h1>{{ greeting_message }}</h1>
+        <p>{{ number_of_people_here }}</p>
     </template>
     <script>
         export default {
@@ -123,13 +124,16 @@ You can also extract the strings marked as translatable inside the <script> sect
             computed: {
                 greeting_message() {
                     return this.$gettext("Hello there!")
+                },
+                number_of_people_here(nb_folks) {
+                    return this.$ngettext("There is ${ n } person here.", "There are ${ n } persons here.", nb_folks)
                 }
             }
         }
     </script>
 ```
 
-> For the moment, only the the extraction of strings localized using the $gettext function of [vue-gettext](https://github.com/Polyconseil/vue-gettext) is supported.
+> For the moment, only the the extraction of strings localized using the $gettext and $ngettext functions of [vue-gettext](https://github.com/Polyconseil/vue-gettext) is supported.
 
 ##### gettext-compile
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,9 +9,10 @@ exports.DEFAULT_FILTERS = [
   'translate',
 ];
 
-exports.DEFAULT_VUE_GETTEXT_FUNCTIONS = [
-  '$gettext',
-];
+exports.DEFAULT_VUE_GETTEXT_FUNCTIONS = {
+  '$gettext': ['msgid'],
+  '$ngettext': ['msgid', 'plural', null],
+};
 
 exports.DEFAULT_START_DELIMITER = '{{';
 exports.DEFAULT_END_DELIMITER = '}}';

--- a/src/extract.spec.js
+++ b/src/extract.spec.js
@@ -78,10 +78,16 @@ describe('Extractor object', () => {
     expect(extractor.toString()).to.equal(fixtures.POT_OUTPUT_QUOTES);
   });
 
-  it('should output a correct POT file with strings extracted from javascript', () => {
+  it('should output a correct POT file with singular strings ($gettext) extracted from javascript', () => {
     const extractor = new extract.Extractor();
     extractor.parseVueJavascript(fixtures.VUE_COMPONENT_FILENAME, fixtures.VUE_COMPONENT_EXPECTED_PROCESSED_SCRIPT_TAG);
-    expect(extractor.toString()).to.equal(fixtures.POT_OUTPUT_VUE_SCRIPT);
+    expect(extractor.toString()).to.equal(fixtures.POT_OUTPUT_VUE_SCRIPT_GETTEXT);
+  });
+
+  it('should output a correct POT file with plural strings ($ngettext) extracted from javascript', () => {
+    const extractor = new extract.Extractor();
+    extractor.parseVueJavascript(fixtures.VUE_COMPONENT_FILENAME, fixtures.SCRIPT_USING_NGETTEXT);
+    expect(extractor.toString()).to.equal(fixtures.POT_OUTPUT_VUE_SCRIPT_NGETTEXT);
   });
 });
 

--- a/src/javascript-extract.js
+++ b/src/javascript-extract.js
@@ -1,9 +1,9 @@
 const acorn = require('acorn');
-const constants = require('./constants.js');
+const { DEFAULT_VUE_GETTEXT_FUNCTIONS } = require('./constants.js');
 const nodeTranslationInfoFactory = require('./node-translation-representation-factory.js');
 
 function isAVueGettextFunction(token) {
-  return constants.DEFAULT_VUE_GETTEXT_FUNCTIONS.includes(token.value);
+  return DEFAULT_VUE_GETTEXT_FUNCTIONS.hasOwnProperty(token.value);
 }
 
 function getGettextTokensFromScript(script) {
@@ -25,15 +25,13 @@ function getLocalizedStringsFromNode(filename, script, token) {
   const expression = acorn.parseExpressionAt(script, token.start);
   const localizedStrings = [];
 
-  for (const argument of expression.arguments) {
-    const nodeTranslation = nodeTranslationInfoFactory.getNodeTranslationInfoRepresentation(
-      filename,
-      argument.value,
-      token.loc.start.line
-    );
+  const nodeTranslation = nodeTranslationInfoFactory.getNodeTranslationInfoRepresentation(
+    filename,
+    token,
+    expression
+  );
 
-    localizedStrings.push(nodeTranslation);
-  }
+  localizedStrings.push(nodeTranslation);
 
   return localizedStrings;
 }

--- a/src/javascript-extract.spec.js
+++ b/src/javascript-extract.spec.js
@@ -6,7 +6,7 @@ const jsExtractor = require('./javascript-extract.js');
 
 describe('Javascript extractor object', () => {
   describe('Extraction of localized strings', () => {
-    it('should extract strings from the script', () => {
+    it('should extract strings localized using $gettext from the script', () => {
       const filename = fixtures.VUE_COMPONENT_FILENAME;
       const extractedStrings = jsExtractor.extractStringsFromJavascript(
         filename,
@@ -18,13 +18,29 @@ describe('Javascript extractor object', () => {
       const firstString = extractedStrings[0];
       const secondString = extractedStrings[1];
 
-      expect(firstString.text).to.be.equal('Hello there!');
+      expect(firstString.msgid).to.be.equal('Hello there!');
       expect(firstString.reference.file).to.be.equal(filename);
       expect(firstString.reference.line).to.be.equal(10);
 
-      expect(secondString.text).to.be.equal('Hello there!');
+      expect(secondString.msgid).to.be.equal('Hello there!');
       expect(secondString.reference.file).to.be.equal(filename);
       expect(secondString.reference.line).to.be.equal(13);
+    });
+
+    it('should extract strings localized using $ngettext from the script', () => {
+      const filename = '$ngettext.vue';
+      const extractedStrings = jsExtractor.extractStringsFromJavascript(
+        filename,
+        fixtures.SCRIPT_USING_NGETTEXT
+      );
+
+      expect(extractedStrings.length).to.be.equal(1);
+
+      const firstString = extractedStrings[0];
+
+      expect(firstString.msgid).to.be.equal('%{ n } foo');
+      expect(firstString.reference.file).to.be.equal(filename);
+      expect(firstString.reference.line).to.be.equal(6);
     });
   });
 });

--- a/src/node-translation-representation-factory.spec.js
+++ b/src/node-translation-representation-factory.spec.js
@@ -4,23 +4,68 @@ const factory = require('./node-translation-representation-factory.js');
 describe('Node translation representation factory', () => {
   describe('Generated objects representations', () => {
     const filename = 'Grievous.vue';
-    const localizedString = 'General Kenobi!';
-    const lineNumber = 4;
 
-    let node;
+    let gettextExpression;
+    let gettextToken;
 
     beforeEach(() => {
-      node = factory.getNodeTranslationInfoRepresentation(filename, localizedString, lineNumber);
+      gettextExpression = {
+        arguments: [
+          {
+            value: 'General Kenobi!',
+          },
+        ],
+      };
+
+      gettextToken = {
+        value: '$gettext',
+        loc: {
+          start: {
+            line: 4,
+          },
+        },
+      };
     });
 
     it('should correctly render the reference', () => {
+      const node = factory.getNodeTranslationInfoRepresentation(filename, gettextToken, gettextExpression);
+
       expect(node.reference.toString(true)).to.be.equal('Grievous.vue:4');
     });
 
-    it('Should correctly render to a PoItem', () => {
+    it('Should correctly render $gettext node representation to a PoItem', () => {
+      const node = factory.getNodeTranslationInfoRepresentation(filename, gettextToken, gettextExpression);
+
       const poItem = node.toPoItem(true);
 
-      expect(poItem.msgid).to.be.equal(localizedString);
+      expect(poItem.msgid).to.be.equal('General Kenobi!');
+      expect(poItem.references).to.have.members([ 'Grievous.vue:4' ]);
+    });
+
+    it('Should correctly render $ngettext node representation to a PoItem', () => {
+      const ngettextExpression = {
+        arguments: [
+          { value: 'one droid' },
+          { value: '%{ n } droids' },
+          { value: null },
+        ],
+      };
+
+      const ngettextToken = {
+        value: '$ngettext',
+        loc: {
+          start: {
+            line: 4,
+          },
+        },
+      };
+
+      const node = factory.getNodeTranslationInfoRepresentation(filename, ngettextToken, ngettextExpression);
+
+      const poItem = node.toPoItem(true);
+
+      expect(poItem.msgid).to.be.equal('one droid');
+      expect(poItem.msgid_plural).to.be.equal('%{ n } droids');
       expect(poItem.references).to.have.members([ 'Grievous.vue:4' ]);
     });
   });

--- a/src/test-fixtures.js
+++ b/src/test-fixtures.js
@@ -288,6 +288,19 @@ export default {
     }
 }`;
 
+exports.SCRIPT_USING_NGETTEXT = `
+    export default {
+        name: "greetings",
+        methods: {
+            alertPlural (n) {
+              let translated = this.$ngettext('%{ n } foo', '%{ n } foos', n)
+              let interpolated = this.$gettextInterpolate(translated, {n: n})
+              return window.alert(interpolated)
+            },
+        }
+    }
+`;
+
 exports.POT_OUTPUT_0 = `msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=utf-8\\n"
@@ -544,7 +557,7 @@ exports.OUTPUT_DICT = {
   },
 };
 
-exports.POT_OUTPUT_VUE_SCRIPT = `msgid ""
+exports.POT_OUTPUT_VUE_SCRIPT_GETTEXT = `msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=utf-8\\n"
 "Content-Transfer-Encoding: 8bit\\n"
@@ -554,4 +567,18 @@ msgstr ""
 #: GreetingsComponent.vue
 msgid "Hello there!"
 msgstr ""
+`;
+
+exports.POT_OUTPUT_VUE_SCRIPT_NGETTEXT = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"Generated-By: easygettext\\n"
+"Project-Id-Version: \\n"
+
+#: GreetingsComponent.vue
+msgid "%{ n } foo"
+msgid_plural "%{ n } foos"
+msgstr[0] ""
+msgstr[1] ""
 `;


### PR DESCRIPTION
This commit makes the extraction of plural strings ($ngettext) possible. It also prepares the support of the two other vue-gettext functions which will be done in the next commits.

How to test
---------------
1. Set up a .vue file containing $ngettext functions like:
```html
    <template>
        <p>{{ number_of_people_here }}</p>
    </template>
    <script>
        export default {
            name: "greetings",
            computed: {
                number_of_people_here(nb_folks) {
                    return this.$ngettext(
                        "There is ${ n } person here.",
                        "There are ${ n } persons here.",
                        nb_folks
                    )
                }
            }
        }
     </script>
```
2. Run compile-cli.js with this file

Expected result
--------------------
- Plural strings present in the script part of the vue component have been successfully extracted.