### PR TITLE
Issue #37 - Extract strings only when expression is a gettext function

### DIFF
--- a/src/javascript-extract.js
+++ b/src/javascript-extract.js
@@ -25,6 +25,10 @@ function getLocalizedStringsFromNode(filename, script, token) {
   const expression = acorn.parseExpressionAt(script, token.start);
   const localizedStrings = [];
 
+  if (expression.type !== 'CallExpression') {
+    return [];
+  }
+
   const nodeTranslation = nodeTranslationInfoFactory.getNodeTranslationInfoRepresentation(
     filename,
     token,

--- a/src/javascript-extract.spec.js
+++ b/src/javascript-extract.spec.js
@@ -42,5 +42,16 @@ describe('Javascript extractor object', () => {
       expect(firstString.reference.file).to.be.equal(filename);
       expect(firstString.reference.line).to.be.equal(6);
     });
+
+    it('should not try to extract strings when the node is not a function', () => {
+      const filename = 'traps.vue';
+      const extractedStrings = jsExtractor.extractStringsFromJavascript(
+        filename,
+        fixtures.SCRIPT_CONTAINING_DECOYS
+      );
+
+      expect(extractedStrings.length).to.be.equal(1);
+      expect(extractedStrings[0].msgid).to.be.equal('Hello world from the $gettext function');
+    });
   });
 });

--- a/src/test-fixtures.js
+++ b/src/test-fixtures.js
@@ -301,6 +301,18 @@ exports.SCRIPT_USING_NGETTEXT = `
     }
 `;
 
+exports.SCRIPT_CONTAINING_DECOYS = `
+import $gettext from '@helper/gettext';
+
+export default {
+  name: "$gettext", // because some people are actually weird
+  computed: {
+    message() {
+      return this.$gettext('Hello world from the $gettext function');
+    }
+  }
+}`;
+
 exports.POT_OUTPUT_0 = `msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=utf-8\\n"


### PR DESCRIPTION
This commit is a fix for issue #37.

The problem came from the extractor that was trying to extract the strings arguments of any gettext-like node without making sure that the type of the current node was a CallExpression.
This fix prevents the extractor to automatically extract strings or variables or whatever called like a vue-gettext function.

How to test:
-------------
1. setup a vue file containing decoys looking like some gettext functions
  like:
```html
<template>
  <h1>{{ message }}<h1>
</template>
<script>
import $gettext from '@helper/gettext';

export default {
  name: "$gettext", // because some people are actually weird
  computed: {
    message() {
      return this.$gettext('Hello world from the $gettext function');
    }
  }
}
</script>
```
2. Run extract-cli with this file.

Expected results
--------------------
- The string "Hello world from the $gettext function" has been
  successfully extracted without any error.