### PR TITLE
Extract $pgettext strings from vue script part

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ You can also extract the strings marked as translatable inside the <script> sect
     </script>
 ```
 
-> For the moment, only the the extraction of strings localized using the $gettext and $ngettext functions of [vue-gettext](https://github.com/Polyconseil/vue-gettext) is supported.
+> For the moment, only the the extraction of strings localized using the $gettext, $ngettext and $pgettext functions of [vue-gettext](https://github.com/Polyconseil/vue-gettext) is supported.
 
 ##### gettext-compile
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,6 +12,7 @@ exports.DEFAULT_FILTERS = [
 exports.DEFAULT_VUE_GETTEXT_FUNCTIONS = {
   '$gettext': ['msgid'],
   '$ngettext': ['msgid', 'plural', null],
+  '$pgettext': ['msgctxt', 'msgid'],
 };
 
 exports.DEFAULT_START_DELIMITER = '{{';

--- a/src/extract.spec.js
+++ b/src/extract.spec.js
@@ -89,6 +89,12 @@ describe('Extractor object', () => {
     extractor.parseVueJavascript(fixtures.VUE_COMPONENT_FILENAME, fixtures.SCRIPT_USING_NGETTEXT);
     expect(extractor.toString()).to.equal(fixtures.POT_OUTPUT_VUE_SCRIPT_NGETTEXT);
   });
+
+  it('should output a correct POT file with contextualized strings ($pgettext) extracted from javascript', () => {
+    const extractor = new extract.Extractor();
+    extractor.parseVueJavascript(fixtures.VUE_COMPONENT_FILENAME, fixtures.SCRIPT_USING_PGETTEXT);
+    expect(extractor.toString()).to.equal(fixtures.POT_OUTPUT_VUE_SCRIPT_PGETTEXT);
+  });
 });
 
 

--- a/src/javascript-extract.spec.js
+++ b/src/javascript-extract.spec.js
@@ -2,6 +2,7 @@ const { expect } = require('chai');
 
 const fixtures = require('./test-fixtures.js');
 const jsExtractor = require('./javascript-extract.js');
+const { MARKER_NO_CONTEXT } = require('./constants.js');
 
 
 describe('Javascript extractor object', () => {
@@ -19,10 +20,12 @@ describe('Javascript extractor object', () => {
       const secondString = extractedStrings[1];
 
       expect(firstString.msgid).to.be.equal('Hello there!');
+      expect(firstString.context).to.be.equal(MARKER_NO_CONTEXT);
       expect(firstString.reference.file).to.be.equal(filename);
       expect(firstString.reference.line).to.be.equal(10);
 
       expect(secondString.msgid).to.be.equal('Hello there!');
+      expect(firstString.context).to.be.equal(MARKER_NO_CONTEXT);
       expect(secondString.reference.file).to.be.equal(filename);
       expect(secondString.reference.line).to.be.equal(13);
     });
@@ -39,8 +42,32 @@ describe('Javascript extractor object', () => {
       const firstString = extractedStrings[0];
 
       expect(firstString.msgid).to.be.equal('%{ n } foo');
+      expect(firstString.context).to.be.equal(MARKER_NO_CONTEXT);
       expect(firstString.reference.file).to.be.equal(filename);
       expect(firstString.reference.line).to.be.equal(6);
+    });
+
+    it('should extract contextual strings localized using $pgettext from the script', () => {
+      const filename = '$ngettext.vue';
+      const extractedStrings = jsExtractor.extractStringsFromJavascript(
+        filename,
+        fixtures.SCRIPT_USING_PGETTEXT
+      );
+
+      expect(extractedStrings.length).to.be.equal(2);
+
+      const firstString = extractedStrings[0];
+      const secondString = extractedStrings[1];
+
+      expect(firstString.msgid).to.be.equal('Home');
+      expect(firstString.context).to.be.equal('menu');
+      expect(firstString.reference.file).to.be.equal(filename);
+      expect(firstString.reference.line).to.be.equal(6);
+
+      expect(secondString.msgid).to.be.equal('Home');
+      expect(secondString.context).to.be.equal('house');
+      expect(secondString.reference.file).to.be.equal(filename);
+      expect(secondString.reference.line).to.be.equal(9);
     });
 
     it('should not try to extract strings when the node is not a function', () => {

--- a/src/node-translation-representation-factory.js
+++ b/src/node-translation-representation-factory.js
@@ -33,22 +33,46 @@ function toPoItem(withLineNumbers = false) {
   poItem.msgid = this.msgid;
   poItem.msgid_plural = this.plural;
   poItem.references = [ this.reference.toString(withLineNumbers) ];
+  poItem.msgctxt = this.msgctxt;
   poItem.msgstr = [];
 
   return poItem;
 }
 
+function hasStringAContext(token) {
+  return DEFAULT_VUE_GETTEXT_FUNCTIONS[ token.value ].includes('msgctxt');
+}
+
+function getGettextParameterIndex(token, targetParameter) {
+  return DEFAULT_VUE_GETTEXT_FUNCTIONS[ token.value ].indexOf(targetParameter);
+}
+
+function getContext(token, gettextAttributes) {
+  if (! hasStringAContext(token)) {
+    return MARKER_NO_CONTEXT;
+  }
+
+  const { msgctxt } = gettextAttributes[
+    getGettextParameterIndex(token, 'msgctxt')
+  ];
+
+  return msgctxt;
+}
+
 function getNodeTranslationInfoRepresentation(filename, token, expression) {
+  const gettextAttributes = getGettextAttributes(token, expression);
+  const context           = getContext(token, gettextAttributes);
+
   return Object.assign(
     {},
-    ...getGettextAttributes(token, expression),
+    ...gettextAttributes,
     {
       reference: {
         file: filename,
         line: token.loc.start.line,
         toString,
       },
-      context: MARKER_NO_CONTEXT,
+      context,
       toPoItem,
     }
   );

--- a/src/node-translation-representation-factory.spec.js
+++ b/src/node-translation-representation-factory.spec.js
@@ -68,5 +68,32 @@ describe('Node translation representation factory', () => {
       expect(poItem.msgid_plural).to.be.equal('%{ n } droids');
       expect(poItem.references).to.have.members([ 'Grievous.vue:4' ]);
     });
+
+
+    it('Should correctly render $pgettext node representation to a PoItem', () => {
+      const ngettextExpression = {
+        arguments: [
+          { value: 'menu' },
+          { value: 'Home' },
+        ],
+      };
+
+      const ngettextToken = {
+        value: '$pgettext',
+        loc: {
+          start: {
+            line: 4,
+          },
+        },
+      };
+
+      const node = factory.getNodeTranslationInfoRepresentation(filename, ngettextToken, ngettextExpression);
+
+      const poItem = node.toPoItem(true);
+
+      expect(poItem.msgid).to.be.equal('Home');
+      expect(poItem.msgctxt).to.be.equal('menu');
+      expect(poItem.references).to.have.members([ 'Grievous.vue:4' ]);
+    });
   });
 });

--- a/src/test-fixtures.js
+++ b/src/test-fixtures.js
@@ -301,6 +301,20 @@ exports.SCRIPT_USING_NGETTEXT = `
     }
 `;
 
+exports.SCRIPT_USING_PGETTEXT = `
+    export default {
+        name: "menuEntry",
+        computed: {
+            getEntryLabel() {
+                return this.$pgettext("menu", "Home")
+            },
+            getEntryLabel() {
+                return this.$pgettext("house", "Home")
+            },
+        }
+    }
+`;
+
 exports.SCRIPT_CONTAINING_DECOYS = `
 import $gettext from '@helper/gettext';
 
@@ -593,4 +607,22 @@ msgid "%{ n } foo"
 msgid_plural "%{ n } foos"
 msgstr[0] ""
 msgstr[1] ""
+`;
+
+exports.POT_OUTPUT_VUE_SCRIPT_PGETTEXT = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"Generated-By: easygettext\\n"
+"Project-Id-Version: \\n"
+
+#: GreetingsComponent.vue
+msgctxt "house"
+msgid "Home"
+msgstr ""
+
+#: GreetingsComponent.vue
+msgctxt "menu"
+msgid "Home"
+msgstr ""
 `;


### PR DESCRIPTION
This commit introduces extraction of contextualized strings from the javascript part of vue components.

How to test:
--------------
1. Set up a .vue file containing contextualized strings like:
```html
<template>
    <ul>
        <li>{{ getMenuEntryLabel }}</li>
        <li>{{ getHousingCategoryLabel }}</li>
    </ul>
</template>
<script>
    export default {
        name: "menuEntry",
        computed: {
            getMenuEntryLabel() {
                return this.$pgettext("menu", "Home")
            },
            getHousingCategoryLabel() {
                return this.$pgettext("house", "Home")
            },
        }
    }
</script>
```
2. Run extract-cli with this file

Expected results:
---------------------
- The two strings have been successfully extracted with their respective contexts.