### PR TITLE
extract $gettext messages from array/object literals

### DIFF
--- a/src/javascript-extract.js
+++ b/src/javascript-extract.js
@@ -22,20 +22,22 @@ function getGettextTokensFromScript(script) {
 }
 
 function getLocalizedStringsFromNode(filename, script, token) {
-  const expression = acorn.parseExpressionAt(script, token.start);
+  let expression = acorn.parseExpressionAt(script, token.start);
   const localizedStrings = [];
 
-  if (expression.type !== 'CallExpression') {
-    return [];
+  if (expression.type == 'SequenceExpression') {
+    expression = expression.expressions[0];
   }
 
-  const nodeTranslation = nodeTranslationInfoFactory.getNodeTranslationInfoRepresentation(
-    filename,
-    token,
-    expression
-  );
+  if (expression.type == 'CallExpression') {
+    const nodeTranslation = nodeTranslationInfoFactory.getNodeTranslationInfoRepresentation(
+      filename,
+      token,
+      expression
+    );
 
-  localizedStrings.push(nodeTranslation);
+    localizedStrings.push(nodeTranslation);
+  }
 
   return localizedStrings;
 }

--- a/src/javascript-extract.spec.js
+++ b/src/javascript-extract.spec.js
@@ -43,6 +43,31 @@ describe('Javascript extractor object', () => {
       expect(firstString.reference.line).to.be.equal(6);
     });
 
+    it('should allow gettext calls in array, object initializers', () => {
+      const filename = fixtures.SCRIPT_GETTEXT_SEQUENCE_FILENAME;
+      const extractedStrings = jsExtractor.extractStringsFromJavascript(
+        filename,
+	fixtures.SCRIPT_GETTEXT_SEQUENCE
+      );
+
+      expect(extractedStrings.length).to.be.equal(3);
+      const firstString = extractedStrings[0];
+      const secondString = extractedStrings[1];
+      const thirdString = extractedStrings[2];
+
+      expect(firstString.msgid).to.be.equal('Hello there!');
+      expect(firstString.reference.file).to.be.equal(filename);
+      expect(firstString.reference.line).to.be.equal(7);
+
+      expect(secondString.msgid).to.be.equal('Hello there!');
+      expect(secondString.reference.file).to.be.equal(filename);
+      expect(secondString.reference.line).to.be.equal(8);
+
+      expect(thirdString.msgid).to.be.equal('Hello there!');
+      expect(thirdString.reference.file).to.be.equal(filename);
+      expect(thirdString.reference.line).to.be.equal(8);
+    });
+
     it('should not try to extract strings when the node is not a function', () => {
       const filename = 'traps.vue';
       const extractedStrings = jsExtractor.extractStringsFromJavascript(

--- a/src/test-fixtures.js
+++ b/src/test-fixtures.js
@@ -313,6 +313,20 @@ export default {
   }
 }`;
 
+exports.SCRIPT_GETTEXT_SEQUENCE_FILENAME = 'gettext_sequence.vue';
+exports.SCRIPT_GETTEXT_SEQUENCE = `
+export default {
+  name: 'greetings-sequence',
+  computed: {
+    messages_object() {
+      return {
+	a_string: this.$gettext('Hello there!'),
+	an_array: [this.$gettext('Hello there!'), this.$gettext('Hello there!')]
+      }
+    }
+  }
+}`;
+
 exports.POT_OUTPUT_0 = `msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=utf-8\\n"


### PR DESCRIPTION
Fixes issue #43 
When $gettext nodes are found in array/object literal constructs acorn parses these as SequenceExpression nodes. The $gettext node will always be the first expression in the sequence, so we replace the expression with the first item in the sequence.