### PR TITLE
Add stage 3 proposal support for Acorn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,30 @@
       "resolved": "https://npm.polydev.blue/acorn/-/acorn-5.5.3.tgz",
       "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
     },
+    "acorn-bigint": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-bigint/-/acorn-bigint-0.2.0.tgz",
+      "integrity": "sha1-D0WlKQU3eZo7BwhWiaGGiBy1N4Q=",
+      "requires": {
+        "acorn": "^5.2.1"
+      }
+    },
+    "acorn-class-fields": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/acorn-class-fields/-/acorn-class-fields-0.1.2.tgz",
+      "integrity": "sha1-IHgvMEr0Ilf+/1vUpcM1KRRzv1g=",
+      "requires": {
+        "acorn": "^5.3.0"
+      }
+    },
+    "acorn-dynamic-import": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
+      "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
+      "requires": {
+        "acorn": "^5.0.0"
+      }
+    },
     "acorn-globals": {
       "version": "3.1.0",
       "resolved": "https://npm.polydev.blue/acorn-globals/-/acorn-globals-3.1.0.tgz",
@@ -56,6 +80,22 @@
           "resolved": "https://npm.polydev.blue/acorn/-/acorn-4.0.13.tgz",
           "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
         }
+      }
+    },
+    "acorn-import-meta": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/acorn-import-meta/-/acorn-import-meta-0.2.1.tgz",
+      "integrity": "sha512-+KB5Q0P0Q/XpsPHgnLx4XbCGqMogw4yiJJjYsbzPCNrE/IoX+c6J4C+BFcwdWh3CD1zLzMxPITN1jzHd+NiS3w==",
+      "requires": {
+        "acorn": "^5.4.1"
+      }
+    },
+    "acorn-json-superset": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-json-superset/-/acorn-json-superset-0.1.0.tgz",
+      "integrity": "sha1-tbkRoXd+pjpI/PxkNT54cwXoqUU=",
+      "requires": {
+        "acorn": "^5.4.1"
       }
     },
     "acorn-jsx": {
@@ -73,6 +113,46 @@
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
+      }
+    },
+    "acorn-numeric-separator": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-numeric-separator/-/acorn-numeric-separator-0.1.1.tgz",
+      "integrity": "sha1-qkVaHZWuiHIx3pfgaBq74osGXo0=",
+      "requires": {
+        "acorn": "^5.2.1"
+      }
+    },
+    "acorn-optional-catch-binding": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-optional-catch-binding/-/acorn-optional-catch-binding-0.1.0.tgz",
+      "integrity": "sha1-2aGHTb/84es0lYNuXnWyrZwwCGg=",
+      "requires": {
+        "acorn": "^5.2.1"
+      }
+    },
+    "acorn-private-methods": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-private-methods/-/acorn-private-methods-0.1.1.tgz",
+      "integrity": "sha1-MsE88k0Fvxyb4EkUtBSRxZ11oZU=",
+      "requires": {
+        "acorn": "^5.4.0"
+      }
+    },
+    "acorn-stage3": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/acorn-stage3/-/acorn-stage3-0.6.0.tgz",
+      "integrity": "sha512-/CZrHonJfg5OSTkZ71w4L4JnpsqZyDIXaSot5gUpQriTUavjiuAjkJBxxNGtxTlGBVtOBtYwzqxLDUSOD3amDQ==",
+      "requires": {
+        "acorn": "^5.5.0",
+        "acorn-bigint": "^0.2.0",
+        "acorn-class-fields": "^0.1.1",
+        "acorn-dynamic-import": "^3.0.0",
+        "acorn-import-meta": "^0.2.1",
+        "acorn-json-superset": "^0.1.0",
+        "acorn-numeric-separator": "^0.1.1",
+        "acorn-optional-catch-binding": "^0.1.0",
+        "acorn-private-methods": "^0.1.1"
       }
     },
     "ajv": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@vue/component-compiler-utils": "^1.2.1",
     "acorn": "^5.5.3",
+    "acorn-stage3": "^0.6.0",
     "cheerio": "^1.0.0-rc.2",
     "minimist": "^1.2.0",
     "pofile": "^1.0.10",

--- a/src/javascript-extract.js
+++ b/src/javascript-extract.js
@@ -1,4 +1,4 @@
-const acorn = require('acorn');
+const acorn = require('acorn-stage3');
 const Pofile = require('pofile');
 
 const {MARKER_NO_CONTEXT, DEFAULT_VUE_GETTEXT_FUNCTIONS} = require('./constants.js');
@@ -29,6 +29,9 @@ function getGettextEntriesFromScript(script) {
     sourceType: 'module',
     locations: true,
     onToken: allTokens,
+    plugins: {
+      stage3: true
+    },
   };
 
   acorn.parse(script, ACORN_OPTIONS);

--- a/src/javascript-extract.spec.js
+++ b/src/javascript-extract.spec.js
@@ -101,5 +101,16 @@ describe('Javascript extractor object', () => {
       expect(extractedStrings.length).to.be.equal(1);
       expect(extractedStrings[0].msgid).to.be.equal('Hello world from the $gettext function');
     });
+
+    it('should not break parser when using ECMAScript Stage 3 features', () => {
+      const filename = 'stage3.vue';
+      const extractedStrings = jsExtractor.extractStringsFromJavascript(
+        filename,
+        fixtures.SCRIPT_WITH_ES_STAGE3_FEATURES
+      );
+
+      expect(extractedStrings.length).to.be.equal(1);
+      expect(extractedStrings[0].msgid).to.be.equal('Hello world from the future');
+    });
   });
 });

--- a/src/test-fixtures.js
+++ b/src/test-fixtures.js
@@ -327,6 +327,11 @@ export default {
   }
 }`;
 
+exports.SCRIPT_WITH_ES_STAGE3_FEATURES = `
+const asyncModule = () => import('module');
+const message = this.$gettext('Hello world from the future');
+`;
+
 exports.SCRIPT_GETTEXT_SEQUENCE_FILENAME = 'gettext_sequence.vue';
 exports.SCRIPT_GETTEXT_SEQUENCE = `
 export default {


### PR DESCRIPTION
Simply registers the stage3 proposal plugin in acorn so that features such as `import()` may become non blocking.

Closes #39 