### PR TITLE
Fix SyntaxError in TypeScript

### DIFF
--- a/src/extract-cli.js
+++ b/src/extract-cli.js
@@ -66,11 +66,18 @@ files.forEach(function(filename) {
     let data = fs.readFileSync(file, {encoding: 'utf-8'}).toString();
     extractor.parse(file, extract.preprocessTemplate(data, ext));
 
-    if (ext !== 'js') {
-      data = extract.preprocessScriptTags(data, ext);
+    let lang = 'js';
+    if (ext === 'vue') {
+      const script = extract.preprocessVueFile(data);
+      if (script) {
+        data = script.content;
+        lang = script.lang;
+      }
     }
 
-    extractor.parseJavascript(file, data);
+    if (lang === 'js') {
+      extractor.parseJavascript(file, data);
+    }
   } catch (e) {
     console.error(`[${PROGRAM_NAME}] could not read: '${filename}`);
     console.trace(e);

--- a/src/extract.js
+++ b/src/extract.js
@@ -49,12 +49,15 @@ exports.TranslationReference = class TranslationReference {
   }
 };
 
-function preprocessScriptTags(data, type) {
+function preprocessVueFile(data) {
   const vueFile = vueCompiler.parse({ source: data, needMap: false });
-
-  return (type !== 'vue' || ! vueFile.script)
-    ? ''
-    : vueFile.script.content.trim();
+  if (!vueFile.script) {
+    return null;
+  }
+  return {
+    content: vueFile.script.content.trim(),
+    lang: vueFile.script.lang || 'js',
+  };
 }
 
 function preprocessTemplate(data, type) {
@@ -80,7 +83,7 @@ function preprocessTemplate(data, type) {
 }
 
 exports.preprocessTemplate   = preprocessTemplate;
-exports.preprocessScriptTags = preprocessScriptTags;
+exports.preprocessVueFile = preprocessVueFile;
 
 exports.NodeTranslationInfo = class NodeTranslationInfo {
   constructor(node, text, reference, attributes) {

--- a/src/extract.spec.js
+++ b/src/extract.spec.js
@@ -111,14 +111,23 @@ describe('data preprocessor', () => {
   });
 
   it('should preprocess VueJS script tag correctly', () => {
-    expect(
-      extract.preprocessScriptTags(
-        fixtures.VUE_COMPONENT_WITH_SCRIPT_TAG,
-        'vue'
-      )
-    ).to.equal(
-      fixtures.VUE_COMPONENT_EXPECTED_PROCESSED_SCRIPT_TAG
-    );
+    const script = extract.preprocessVueFile(fixtures.VUE_COMPONENT_WITH_SCRIPT_TAG);
+
+    expect(script.content).to.equal(fixtures.VUE_COMPONENT_EXPECTED_PROCESSED_SCRIPT_TAG);
+    expect(script.lang).to.equal('js');
+  });
+
+  it('should preprocess VueJS no script tag correctly', () => {
+    const script = extract.preprocessVueFile(fixtures.VUE_COMPONENT_WITHOUT_SCRIPT_TAG);
+
+    expect(script).to.null;
+  });
+
+  it('should preprocess VueJS script tag in TypeScript correctly', () => {
+    const script = extract.preprocessVueFile(fixtures.VUE_COMPONENT_WITH_TS_SCRIPT_TAG);
+
+    expect(script.content).to.equal(fixtures.VUE_COMPONENT_EXPECTED_PROCESSED_TS_SCRIPT_TAG);
+    expect(script.lang).to.equal('ts');
   });
 
 });

--- a/src/test-fixtures.js
+++ b/src/test-fixtures.js
@@ -29,7 +29,7 @@ exports.HTML_FILTER_SPLIT_STRING = `
 `;
 
 exports.HTML_FILTER_ESCAPED_QUOTES = `
-{{ 'Life\\'s a tough teacher.' |translate}} 
+{{ 'Life\\'s a tough teacher.' |translate}}
 {{ "Life's a tough journey." |translate}}
 {{ "Life\\'s a tough road." |translate}}
 {{ "Life's a tough \\"boulevard\\"." |translate}}
@@ -38,7 +38,7 @@ exports.HTML_FILTER_ESCAPED_QUOTES = `
 
 exports.HTML_VARIED_CHALLENGES = `
 <div aria-label="Message Selected Users">
-  <button type="button" 
+  <button type="button"
           ng-class="{'active': vm.messageView === 'preview', disabled: !vm.useHtml}"
           ng-bind="vm.messageView !== 'preview' ? 'Preview' : 'Exit Preview' |translate"></button>
   <div>
@@ -87,10 +87,10 @@ exports.HTML_LINEBREAK_FILTER = `
 <a href="#"
   ng-click="vm.doSomething()"
   class="button">{{ 'Multi-line 0' |translate }}</a>
-  
+
 <a href="#"
   ng-click="vm.doSomething()"
-  class="button">{{ 
+  class="button">{{
  'Multi-line 1' |translate }}</a>
 
 <a href="#"
@@ -105,7 +105,7 @@ exports.HTML_LINEBREAK_FILTER = `
 
 <a href="#"
   ng-click="vm.doSomething()"
-  class="button">{{ 'Multi-line 4' | translate 
+  class="button">{{ 'Multi-line 4' | translate
 }}</a>
 `;
 
@@ -269,6 +269,12 @@ exports.VUE_COMPONENT_WITH_SCRIPT_TAG = `
      </script>
 `;
 
+exports.VUE_COMPONENT_WITHOUT_SCRIPT_TAG = `
+    <template>
+        <h1>Hello</h1>
+    </template>
+`;
+
 exports.VUE_COMPONENT_EXPECTED_PROCESSED_SCRIPT_TAG = `//
 //
 //
@@ -289,6 +295,57 @@ export default {
     },
     methods: {
         async getGreetingMessageAnswer() {
+            return await Promise.resolve('General Kenobi!');
+        }
+    }
+}`;
+
+exports.VUE_COMPONENT_WITH_TS_SCRIPT_TAG = `
+    <template>
+        <h1>{{ greeting_message }}</h1>
+    </template>
+    <script lang="ts">
+        type Message = string;
+
+        export default {
+            name: "greetings",
+            computed: {
+                greeting_message(): Message {
+                    return this.$gettext("Hello there!")
+                },
+                duplicated_greeting_message(): Message {
+                    return this.$gettext("Hello there!")
+                },
+                answer_message(): Message {
+                    return this.$gettext("General Kenobi! You are a bold one.")
+                }
+            },
+            methods: {
+                async getGreetingMessageAnswer(): Promise<Message> {
+                    return await Promise.resolve('General Kenobi!');
+                }
+            }
+        }
+     </script>
+`;
+
+exports.VUE_COMPONENT_EXPECTED_PROCESSED_TS_SCRIPT_TAG = `type Message = string;
+
+export default {
+    name: "greetings",
+    computed: {
+        greeting_message(): Message {
+            return this.$gettext("Hello there!")
+        },
+        duplicated_greeting_message(): Message {
+            return this.$gettext("Hello there!")
+        },
+        answer_message(): Message {
+            return this.$gettext("General Kenobi! You are a bold one.")
+        }
+    },
+    methods: {
+        async getGreetingMessageAnswer(): Promise<Message> {
             return await Promise.resolve('General Kenobi!');
         }
     }


### PR DESCRIPTION
This pull request is related to #55.

After pull request #53, gettext-extract doesn't work in TypeScript with the following `SyntaxError`:
```
> npx gettext-extract --output locales/messages-template.pot --attribute v-translate --parseScript false src/*.vue src/components/*.vue src/views/*/*.vue

[easygettext] extracting: 'src/App.vue
[easygettext] could not read: 'src/App.vue
Trace: { SyntaxError: Unexpected character '@' (24:0)
    at Parser.pp$4.raise (/Users/junichi/Projects/tenri-ui/node_modules/acorn/dist/acorn.js:2757:13)
    at Parser.pp$8.getTokenFromCode (/Users/junichi/Projects/tenri-ui/node_modules/acorn/dist/acorn.js:4906:8)
    at Parser.<anonymous> (/Users/junichi/Projects/tenri-ui/node_modules/acorn-class-fields/inject.js:41:21)
    at Parser.getTokenFromCode (/Users/junichi/Projects/tenri-ui/node_modules/acorn-private-methods/inject.js:30:21)
    at Parser.pp$8.readToken (/Users/junichi/Projects/tenri-ui/node_modules/acorn/dist/acorn.js:4628:15)
    at Parser.pp$8.nextToken (/Users/junichi/Projects/tenri-ui/node_modules/acorn/dist/acorn.js:4619:15)
    at Parser.pp$8.next (/Users/junichi/Projects/tenri-ui/node_modules/acorn/dist/acorn.js:4576:8)
    at Parser.pp.eat (/Users/junichi/Projects/tenri-ui/node_modules/acorn/dist/acorn.js:577:10)
    at Parser.pp.semicolon (/Users/junichi/Projects/tenri-ui/node_modules/acorn/dist/acorn.js:624:13)
    at Parser.pp$1.parseImport (/Users/junichi/Projects/tenri-ui/node_modules/acorn/dist/acorn.js:1482:8)
    at Parser.pp$1.parseStatement (/Users/junichi/Projects/tenri-ui/node_modules/acorn/dist/acorn.js:801:47)
    at Parser.parseStatement (/Users/junichi/Projects/tenri-ui/node_modules/acorn-dynamic-import/lib/inject.js:47:31)
    at Parser.parseStatement (/Users/junichi/Projects/tenri-ui/node_modules/acorn-import-meta/inject.js:39:50)
    at Parser.pp$1.parseTopLevel (/Users/junichi/Projects/tenri-ui/node_modules/acorn/dist/acorn.js:706:23)
    at Parser.parse (/Users/junichi/Projects/tenri-ui/node_modules/acorn/dist/acorn.js:551:15)
    at Object.parse (/Users/junichi/Projects/tenri-ui/node_modules/acorn/dist/acorn.js:5288:37)
  pos: 916,
  loc: Position { line: 24, column: 0 },
  raisedAt: 916 }
    at /Users/junichi/Projects/tenri-ui/node_modules/easygettext/src/extract-cli.js:76:13
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/Users/junichi/Projects/tenri-ui/node_modules/easygettext/src/extract-cli.js:57:7)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at findNodeScript.then.existing (/usr/local/lib/node_modules/npm/node_modules/libnpx/index.js:268:14)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! tenri-ui@0.1.0 i18n:extract-template: `npx gettext-extract --output locales/messages-template.pot --attribute v-translate --parseScript false src/*.vue src/components/*.vue src/views/*/*.vue`
npm ERR! Exit status 1
```

To avoid the error, I added the detecting that the script is TypeScript and avoid the parsing.

Could you review this pull request?