### PR TITLE
extract-cli should not crash when there is no <script> tag in a Vue file

### DIFF
--- a/src/extract-cli.js
+++ b/src/extract-cli.js
@@ -72,6 +72,8 @@ files.forEach(function(filename) {
       if (script) {
         data = script.content;
         lang = script.lang;
+      } else {
+        lang = null;
       }
     }
 


### PR DESCRIPTION
The issue has been introduced by dc49c36adeb458ea48e1d5a4f965e1c75a83d674.
The CLI always expects there is some Javascript/Typescript content to parse
when processing a Vue file. That might not be the case (e.g. a functionnal
single-file component).