### PR TITLE
added string concatenation and template string support for javascript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Change Log
+
+## Not released yet
+
+- Added support for multiline strings [\#67](https://github.com/Polyconseil/easygettext/pull/67)
+- Added support for template strings without variables [\#67](https://github.com/Polyconseil/easygettext/pull/67)

--- a/README.md
+++ b/README.md
@@ -103,6 +103,18 @@ gettext-extract somefile.js
 
 const myVar = $gettext("My fantastic msgid")
 
+const myConcatVar = $gettext(
+  "My"
+  + "fantastic"
+  + "msgid"
+)
+
+const myTempVar = $gettext(
+  `My
+  fantastic
+  msgid`
+)
+
 const myContextualizedVar = $pgettext("some context", "Some other string")
 
 const myPluralVar = $ngettext(...)
@@ -112,7 +124,7 @@ We recognize the ``$gettext``, ``$pgettext`` and ``$ngettext`` tokens as the one
 
 Those tokens are frozen for now, but feel free to make a pull request and add support for variable ones :)
 
-We currently can't extract template strings though.
+We currently can't extract **template strings with variables** though.
 
 
 ##### Extract from Vue components

--- a/src/javascript-extract.spec.js
+++ b/src/javascript-extract.spec.js
@@ -116,5 +116,15 @@ describe('Javascript extractor object', () => {
       expect(extractedStrings.length).toBe(1);
       expect(extractedStrings[0].msgid).toBe('Hello world from the future');
     });
+
+    it('should be able to parse correctly concatenated strings', () => {
+      const filename = 'temp_literals.vue';
+      const extractedStrings = jsExtractor.extractStringsFromJavascript(
+        filename,
+        fixtures.SCRIPT_WITH_STRING_CONCAT
+      );
+      expect(extractedStrings.length).toBe(3);
+      expect(extractedStrings[0].msgid).toBe('Hello there! I am a concatenated string, please translate me.');
+    });
   });
 });

--- a/src/javascript-extract.spec.js
+++ b/src/javascript-extract.spec.js
@@ -124,7 +124,30 @@ describe('Javascript extractor object', () => {
         fixtures.SCRIPT_WITH_STRING_CONCAT
       );
       expect(extractedStrings.length).toBe(3);
-      expect(extractedStrings[0].msgid).toBe('Hello there! I am a concatenated string, please translate me.');
+      expect(extractedStrings[0].msgid).toBe('Hello there! I am a concatenated string,\n please translate me.');
+    });
+
+    it('should be able to parse correctly template strings without variables', () => {
+      const filename = 'temp_literals.vue';
+      const extractedStrings = jsExtractor.extractStringsFromJavascript(
+        filename,
+        fixtures.SCRIPT_WITH_TEMPLATE_LITERALS
+      );
+      expect(extractedStrings.length).toBe(3);
+      expect(extractedStrings[0].msgid).toBe(
+        'Hello there!\n'
+        + 'I am a multiline string,\n'
+        + 'please translate me.');
+    });
+
+    it('should throw when trying to parse template strings with variables', () => {
+      const filename = 'temp_literals.vue';
+      expect(() => {
+        jsExtractor.extractStringsFromJavascript(
+          filename,
+          fixtures.SCRIPT_WITH_TEMPLATE_LITERALS_WITH_VARIABLES
+        );
+      }).toThrow();
     });
   });
 });

--- a/src/test-fixtures.js
+++ b/src/test-fixtures.js
@@ -409,6 +409,41 @@ export default {
     }
 }`;
 
+exports.SCRIPT_WITH_STRING_CONCAT = `
+export default {
+    name: "greetings",
+    computed: {
+        greeting_message() {
+            return this.$gettext(
+              "Hello there!"
+              + " I am a concatenated string,"
+              + "\\n"
+              + " please translate me."
+            )
+        },
+        duplicated_greeting_message() {
+            return this.$gettext(
+              "Hello there!" +
+              " I am a concatenated string," +
+              "\\n" +
+              " please translate me."
+            )
+        },
+        answer_message() {
+            return this.$gettext(
+              "General Kenobi!"
+              + "You are a bold one."
+            )
+        }
+    },
+    methods: {
+        async getGreetingMessageAnswer() {
+            return await Promise.resolve('General Kenobi!');
+        }
+    }
+}
+`;
+
 exports.SCRIPT_USING_NGETTEXT = `
     export default {
         name: "greetings",

--- a/src/test-fixtures.js
+++ b/src/test-fixtures.js
@@ -409,6 +409,51 @@ export default {
     }
 }`;
 
+exports.SCRIPT_WITH_TEMPLATE_LITERALS = `
+export default {
+    name: "greetings",
+    computed: {
+        greeting_message() {
+            return this.$gettext(\`
+Hello there!
+I am a multiline string,
+please translate me.\`)
+        },
+        duplicated_greeting_message() {
+            return this.$gettext(\`
+Hello there!
+I am a multiline string,
+please translate me.\`)
+        },
+        answer_message() {
+            return this.$gettext(\`General Kenobi! You are a bold one.\`)
+        }
+    },
+    methods: {
+        async getGreetingMessageAnswer() {
+            return await Promise.resolve('General Kenobi!');
+        }
+    }
+}
+`;
+
+exports.SCRIPT_WITH_TEMPLATE_LITERALS_WITH_VARIABLES = `
+export default {
+    name: "greetings",
+    computed: {
+        answer_message() {
+            const name = "Kenobi"
+            return this.$gettext(\`General \${name}! You are a bold one.\`)
+        }
+    },
+    methods: {
+        async getGreetingMessageAnswer() {
+            return await Promise.resolve('General Kenobi!');
+        }
+    }
+}
+`;
+
 exports.SCRIPT_WITH_STRING_CONCAT = `
 export default {
     name: "greetings",


### PR DESCRIPTION
This pull request has two parts:

- String concatenation like following should be possible after this pull request:
``` javascript
export default {
    name: "greetings",
    computed: {
        greeting_message() {
            return this.$gettext(
              "Hello there!"
              + " I am a concatenated string,"
              + "\\n"
              + " please translate me."
            )
        },
    },
}
```

- Use of template string for multiline string **without** the use of variable interpolation:
``` javascript
export default {
    name: "greetings",
    computed: {
        greeting_message() {
            return this.$gettext(`
Hello there!
I am a multiline string,
please translate me.`)
        },
    }
}
```