### PR TITLE
Trim HTML content

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ gettext-extract --attribute v-translate --attribute v-i18n --output dictionary.p
 gettext-extract --startDelimiter '[#' --endDelimiter '#]' --output dictionary.pot foo.html bar.jade
 ```
 
+`gettext-extract` can also remove optional HTML whitespaces inside tags to translate (see [PR 68](https://github.com/Polyconseil/easygettext/pull/68) for more information):
+
+```
+gettext-extract --removeHTMLWhitespaces --output dictionary.pot foo.html
+```
+
 
 ##### Javascript/ES7 token extraction
 

--- a/src/extract-cli.js
+++ b/src/extract-cli.js
@@ -21,6 +21,7 @@ const endDelimiter = argv.endDelimiter === undefined ? constants.DEFAULT_DELIMIT
 // Allow to pass extra attributes, e.g. gettext-extract --attribute v-translate --attribute v-i18n
 const extraAttribute = argv.attribute || false;
 const extraFilter = argv.filter || false;
+const removeHTMLWhitespaces = argv.removeHTMLWhitespaces || false;
 const filterPrefix = argv.filterPrefix || constants.DEFAULT_FILTER_PREFIX;
 
 if (!quietMode && (!files || files.length === 0)) {
@@ -51,6 +52,7 @@ const extractor = new extract.Extractor({
   filterPrefix,
   startDelimiter,
   endDelimiter,
+  removeHTMLWhitespaces,
 });
 
 

--- a/src/extract.spec.js
+++ b/src/extract.spec.js
@@ -364,6 +364,16 @@ describe('Raw translation data', () => {
     expect(data[3].text).toEqual('Votes <i class=\'fa fa-star\'></i>');
   });
 
+  it('should remove optional HTML whitespaces', () => {
+    const extractorWithBindOnce = new extract.Extractor({
+      removeHTMLWhitespaces: true
+    });
+    const data = extractorWithBindOnce._extractTranslationData(fixtures.FILENAME_0, fixtures.HTML_OPTIONAL_WHITESPACES);
+
+    expect(data.length).toEqual(1);
+    expect(data[0].text).toEqual(`It's software you install on your server!`);
+  })
+
   it('should extract filters that are broken across multiple lines', () => {
     const extractorInterpolate = new extract.Extractor({
       startDelimiter: '{{',

--- a/src/test-fixtures.js
+++ b/src/test-fixtures.js
@@ -166,6 +166,13 @@ ${exports.HTML_COMPLEX_NESTING}
 -->
 `;
 
+exports.HTML_OPTIONAL_WHITESPACES = `
+<strong translate>It's software you install
+           on your server!
+
+  </strong>
+`;
+
 exports.HTML4_TAG0 = '<translate>Duck</translate>';
 exports.HTML4_TAG1 = '<i18n>Dice</i18n>';
 exports.HTML4_TAG2 = '<get-text>Rabbit</get-text>';


### PR DESCRIPTION
Hi,

This is a proposal. Before fixing tests and adding this feature under a flag (because it could break some existing setups) I wanted to know if you were interested.

In HTML we can add extra spaces and line breaks (when we have long lines for example) with no effects. But easygettext extracts these extra spaces/line breaks which can confuse translators.

Example in Weblate:

![screen_2019-10-23-15:41:54](https://user-images.githubusercontent.com/5180488/67399323-59b93200-f5ac-11e9-9fd4-ee9446328443.png)

This PR removes them using the https://medium.com/@patrickbrosset/when-does-white-space-matter-in-html-b90e8a7cdd33 algorithm

So:

```
#: src/views/FAQ.vue:115
msgid ""
"<strong>It's software you install on your server</strong> to create a website where videos are hosted and broadcast...\n"
"            Basically: you create your own \"homemade YouTube\"!"
```

becomes

```
msgid "<strong>It's software you install on your server</strong> to create a website where videos are hosted and broadcast... Basically: you create your own \"homemade YouTube\"!"
``` 

And the image above becomes in weblate:

![screen_2019-10-23-15:47:43](https://user-images.githubusercontent.com/5180488/67399433-89683a00-f5ac-11e9-9a08-e2bbc92b8c03.png)
