### PR TITLE
extract: Fix parsing HTML

### DIFF
--- a/src/extract-cli.js
+++ b/src/extract-cli.js
@@ -67,21 +67,7 @@ files.forEach(function(filename) {
   try {
     let data = fs.readFileSync(file, {encoding: 'utf-8'}).toString();
     extractor.parse(file, extract.preprocessTemplate(data, ext));
-
-    let lang = 'js';
-    if (ext === 'vue') {
-      const script = extract.preprocessVueFile(data);
-      if (script) {
-        data = script.content;
-        lang = script.lang;
-      } else {
-        lang = null;
-      }
-    }
-
-    if (lang === 'js') {
-      extractor.parseJavascript(file, data);
-    }
+    extractor.parseJavascript(file, extract.preprocessJavascript(data, ext));
   } catch (e) {
     console.error(`[${PROGRAM_NAME}] could not read: '${filename}`);
     console.trace(e);

--- a/src/extract.js
+++ b/src/extract.js
@@ -51,15 +51,18 @@ exports.TranslationReference = class TranslationReference {
   }
 };
 
-function preprocessVueFile(data) {
-  const vueFile = vueCompiler.parse({ compiler, source: data, needMap: false });
-  if (!vueFile.script) {
-    return null;
+function preprocessJavascript(data, type) {
+  let scriptData = '';
+  switch (type) {
+  case 'vue':
+    const vueFile = vueCompiler.parse({ compiler, source: data, needMap: false });
+    if (!vueFile.script) return '';
+    scriptData = vueFile.script.content.trim();
+    break;
+  default:
+    break;
   }
-  return {
-    content: vueFile.script.content.trim(),
-    lang: vueFile.script.lang || 'js',
-  };
+  return scriptData;
 }
 
 function preprocessTemplate(data, type) {
@@ -85,7 +88,7 @@ function preprocessTemplate(data, type) {
 }
 
 exports.preprocessTemplate   = preprocessTemplate;
-exports.preprocessVueFile = preprocessVueFile;
+exports.preprocessJavascript = preprocessJavascript;
 
 exports.NodeTranslationInfo = class NodeTranslationInfo {
   constructor(node, text, reference, attributes) {

--- a/src/extract.spec.js
+++ b/src/extract.spec.js
@@ -121,29 +121,26 @@ describe('data preprocessor', () => {
   });
 
   it('should preprocess VueJS script tag correctly', () => {
-    const script = extract.preprocessVueFile(fixtures.VUE_COMPONENT_WITH_SCRIPT_TAG);
+    const script = extract.preprocessJavascript(fixtures.VUE_COMPONENT_WITH_SCRIPT_TAG, 'vue');
 
-    expect(script.content).toEqual(fixtures.VUE_COMPONENT_EXPECTED_PROCESSED_SCRIPT_TAG);
-    expect(script.lang).toEqual('js');
+    expect(script).toEqual(fixtures.VUE_COMPONENT_EXPECTED_PROCESSED_SCRIPT_TAG);
   });
 
   it('should preprocess VueJS no script tag correctly', () => {
-    const script = extract.preprocessVueFile(fixtures.VUE_COMPONENT_WITHOUT_SCRIPT_TAG);
+    const script = extract.preprocessJavascript(fixtures.VUE_COMPONENT_WITHOUT_SCRIPT_TAG, 'vue');
 
-    expect(script).toBe(null);
+    expect(script).toBe('');
   });
 
   it('should preprocess VueJS script tag in TypeScript correctly', () => {
-    const script = extract.preprocessVueFile(fixtures.VUE_COMPONENT_WITH_TS_SCRIPT_TAG);
+    const script = extract.preprocessJavascript(fixtures.VUE_COMPONENT_WITH_TS_SCRIPT_TAG, 'vue');
 
-    expect(script.content).toEqual(fixtures.VUE_COMPONENT_EXPECTED_PROCESSED_TS_SCRIPT_TAG);
-    expect(script.lang).toEqual('ts');
+    expect(script).toEqual(fixtures.VUE_COMPONENT_EXPECTED_PROCESSED_TS_SCRIPT_TAG);
   });
 
   it('should preprocess VueJS script tag with Flow', () => {
-    const script = extract.preprocessVueFile(fixtures.VUE_COMPONENT_WITH_FLOW_SCRIPT_TAG);
-    expect(script.content).toEqual(fixtures.VUE_COMPONENT_EXPECTED_PROCESSED_FLOW_SCRIPT_TAG);
-    expect(script.lang).toEqual('js');
+    const script = extract.preprocessJavascript(fixtures.VUE_COMPONENT_WITH_FLOW_SCRIPT_TAG, 'vue');
+    expect(script).toEqual(fixtures.VUE_COMPONENT_EXPECTED_PROCESSED_FLOW_SCRIPT_TAG);
   });
 });
 


### PR DESCRIPTION
Commit dc49c36adeb458ea48e1d5a4f965e1c75a83d674 introduced a subtle bug:
while the previous implementation of extract-cli would always override
`data` with the returned value of `preprocessScriptTags`, leading to an
empty value in case of an error, the new implementation didn't do so and
left it as-is. Then, it passed the data to `parseJavascript`,
effectively trying to parse HTML using acorn, which crashes.

This commit moves logic out from extract-cli.js back into extract.js,
using a similar function composition for Javascript as there exists for
templates. The behaviour should be the same, except now we effectively
return an empty string to be passed to parseJavascript, and not the raw
HTML.

This should fix issue https://github.com/Polyconseil/easygettext/issues/73