### PR TITLE
Extract strings marked with $gettext() call in vue templates

### DIFF
--- a/src/extract-cli.js
+++ b/src/extract-cli.js
@@ -68,14 +68,7 @@ files.forEach(function(filename) {
   console.log(`[${PROGRAM_NAME}] extracting: '${filename}`);
   try {
     let data = fs.readFileSync(file, {encoding: 'utf-8'}).toString();
-    extractor.parse(file, extract.preprocessTemplate(data, ext));
-    const script = extract.preprocessScript(data, ext);
-
-    if ((script && script.lang === 'ts') || ext === 'ts') {
-      extractor.parseTypeScript(file, script.content);
-    } else {
-      extractor.parseJavascript(file, script.content);
-    }
+    extractor.extract(file, ext, data);
   } catch (e) {
     console.error(`[${PROGRAM_NAME}] could not read: '${filename}`);
     console.trace(e);

--- a/src/extract.spec.js
+++ b/src/extract.spec.js
@@ -105,6 +105,12 @@ describe('Extractor object', () => {
     extractor.parseJavascript(fixtures.VUE_COMPONENT_FILENAME, fixtures.VUE_COMPONENT_EXPECTED_PROCESSED_FLOW_SCRIPT_TAG);
     expect(extractor.toString()).toEqual(fixtures.POT_OUTPUT_VUE_SCRIPT_GETTEXT);
   });
+
+  it('should output a correct POT file for vue component with $gettext used in template', ()=> {
+    const extractor = new extract.Extractor({attributes: ['v-translate']});
+    extractor.extract(fixtures.VUE_COMPONENT_FILENAME, 'vue', fixtures.VUE_COMPONENT_WITH_GETTEXT_IN_TEMPLATE);
+    expect(extractor.toString()).toEqual(fixtures.POT_OUTPUT_VUE_COMPONENT_WITH_GETTEXT_IN_TEMPLATE);
+  });
 });
 
 
@@ -121,22 +127,22 @@ describe('data preprocessor', () => {
   });
 
   it('should preprocess VueJS script tag correctly', () => {
-    const script = extract.preprocessScript(fixtures.VUE_COMPONENT_WITH_SCRIPT_TAG, 'vue');
+    const [script] = extract.preprocessScript(fixtures.VUE_COMPONENT_WITH_SCRIPT_TAG, 'vue');
     expect(script.content).toEqual(fixtures.VUE_COMPONENT_EXPECTED_PROCESSED_SCRIPT_TAG);
   });
 
   it('should preprocess VueJS no script tag correctly', () => {
-    const script = extract.preprocessScript(fixtures.VUE_COMPONENT_WITHOUT_SCRIPT_TAG, 'vue');
+    const [script] = extract.preprocessScript(fixtures.VUE_COMPONENT_WITHOUT_SCRIPT_TAG, 'vue');
     expect(script.content).toBe('');
   });
 
   it('should preprocess VueJS script tag in TypeScript correctly', () => {
-    const script = extract.preprocessScript(fixtures.VUE_COMPONENT_WITH_TS_SCRIPT_TAG, 'vue');
+    const [script] = extract.preprocessScript(fixtures.VUE_COMPONENT_WITH_TS_SCRIPT_TAG, 'vue');
     expect(script.content).toEqual(fixtures.VUE_COMPONENT_EXPECTED_PROCESSED_TS_SCRIPT_TAG);
   });
 
   it('should preprocess VueJS script tag with Flow', () => {
-    const script = extract.preprocessScript(fixtures.VUE_COMPONENT_WITH_FLOW_SCRIPT_TAG, 'vue');
+    const [script] = extract.preprocessScript(fixtures.VUE_COMPONENT_WITH_FLOW_SCRIPT_TAG, 'vue');
     expect(script.content).toEqual(fixtures.VUE_COMPONENT_EXPECTED_PROCESSED_FLOW_SCRIPT_TAG);
   });
 });

--- a/src/test-fixtures.js
+++ b/src/test-fixtures.js
@@ -282,6 +282,43 @@ exports.VUE_COMPONENT_WITHOUT_SCRIPT_TAG = `
     </template>
 `;
 
+exports.VUE_COMPONENT_WITH_GETTEXT_IN_TEMPLATE = `
+    <template>
+        <article>
+        <a :title="$gettext('Link title')" v-translate>Link body</a>
+        {{ comment }}
+        </article>
+    </template>
+    <script>
+    export default {
+      computed: {
+        comment() {
+          return this.$gettext('Link comment');
+        }
+      }
+    }
+    </script>
+`;
+exports.POT_OUTPUT_VUE_COMPONENT_WITH_GETTEXT_IN_TEMPLATE = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"Generated-By: easygettext\\n"
+"Project-Id-Version: \\n"
+
+#: GreetingsComponent.vue
+msgid "Link body"
+msgstr ""
+
+#: GreetingsComponent.vue
+msgid "Link comment"
+msgstr ""
+
+#: GreetingsComponent.vue
+msgid "Link title"
+msgstr ""
+`
+
 exports.VUE_COMPONENT_EXPECTED_PROCESSED_SCRIPT_TAG = `//
 //
 //


### PR DESCRIPTION
This PR adds code that compiles vue templates before extracting strings from them and after that runs extractor on both raw template string (current behavior) and compiled template code.

Template example where such extraction is needed:

```
<template>
  <a :title="$gettext('Link title')" />
</template>
````