### PR TITLE
Support for multiple templates in vue

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Radically simple gettext tokens extraction tool for:
 - Javascript/ES7+
 - Vue
 - TypeScript (see [Known Issues](#known-issues))
+- Nativescript Vue with [native and web shared code](https://www.nativescript.org/vue)
 
 files.
 

--- a/src/extract.js
+++ b/src/extract.js
@@ -91,13 +91,12 @@ function preprocessTemplate(data, type) {
     });
 
     templateData = $('template').map(function() {
-      const t = $.html($(this));
-      const vueFile = vueCompiler.parse({ compiler, source: t, needMap: false});
+      let lang = $(this).attr('lang');
 
-      if (vueFile.template.lang) {
-        return preprocessTemplate(($(this)).html(), vueFile.template.lang);
+      if (lang) {
+        return preprocessTemplate($(this).html(), lang);
       }
-      return vueFile.template.content.trim();
+      return $(this).html().trim();
     }).toArray();
 
     // if there is just one template, use it as a string

--- a/src/extract.spec.js
+++ b/src/extract.spec.js
@@ -126,6 +126,14 @@ describe('data preprocessor', () => {
     expect(extract.preprocessTemplate("<template lang='jade'>h1 hello</template>", 'vue')).toEqual('<h1>hello</h1>');
   });
 
+  it('should preprocess VueJS with multiple templates correctly', () => {
+    expect(extract.preprocessTemplate(
+      '<template web><h1>hello</h1></template><template native><Page class="page"><Label text="World"/></Page></template>', 'vue'
+    )).toEqual(
+      ['<h1>hello</h1>', '<Page class="page"><Label text="World"/></Page>']
+    );
+  });
+
   it('should preprocess VueJS script tag correctly', () => {
     const [script] = extract.preprocessScript(fixtures.VUE_COMPONENT_WITH_SCRIPT_TAG, 'vue');
     expect(script.content).toEqual(fixtures.VUE_COMPONENT_EXPECTED_PROCESSED_SCRIPT_TAG);


### PR DESCRIPTION
Solves #80. Since vue compiler does not support multiple templates, my approach was to use cheerios to get the templates and then parse each one individually. Unit test was added as well, suite is passing. Thanks for the tip and hope you merge and release this soon :)