### PR TITLE
enable parsing next typescript features

### DIFF
--- a/src/test-fixtures.js
+++ b/src/test-fixtures.js
@@ -317,7 +317,7 @@ msgstr ""
 #: GreetingsComponent.vue
 msgid "Link title"
 msgstr ""
-`
+`;
 
 exports.VUE_COMPONENT_EXPECTED_PROCESSED_SCRIPT_TAG = `//
 //
@@ -965,6 +965,11 @@ export default {
       return {
         an_array: [this.$gettext('Hello there!'), this.$gettext('Hello there!')],
         a_string: this.$gettext('Hello there!'),
+      }
+    },
+    object_using_next_typescript_features(): MessageObject {
+      return {
+        a_string: this?.$gettext('Hello there!'),
       }
     }
   }

--- a/src/typescript-extract.js
+++ b/src/typescript-extract.js
@@ -42,7 +42,7 @@ function getTranslationObject(node, gettextFunctionName, filename) {
 
 function getGettextEntriesFromTypeScript(script, filename) {
   let translationEntries = [];
-  walk(parseTSScript(script, {loc: true}), {
+  walk(parseTSScript(script, {loc: true, next: true}), {
     enter: function(node) {
       if (node.type && node.type === 'CallExpression' && node.callee) {
         if (DEFAULT_VUE_GETTEXT_FUNCTIONS_KEYS.includes(node.callee.name)) {

--- a/src/typescript-extract.spec.js
+++ b/src/typescript-extract.spec.js
@@ -57,10 +57,11 @@ describe('TypeScript extractor object', () => {
         filename,
         fixtures.SCRIPT_GETTEXT_SEQUENCE_TS
       );
-      expect(extractedStrings.length).toBe(3);
+      expect(extractedStrings.length).toBe(4);
       const firstString = extractedStrings[0];
       const secondString = extractedStrings[1];
       const thirdString = extractedStrings[2];
+      const fourthString = extractedStrings[3];
       expect(firstString.msgid).toBe('Hello there!');
       expect(firstString.reference.file).toBe(filename);
       // expect(firstString.reference.line).toBe(7);
@@ -70,6 +71,8 @@ describe('TypeScript extractor object', () => {
       expect(thirdString.msgid).toBe('Hello there!');
       expect(thirdString.reference.file).toBe(filename);
       // expect(thirdString.reference.line).toBe(8);
+      expect(fourthString.msgid).toBe('Hello there!');
+      expect(fourthString.reference.file).toBe(filename);
     });
 
     it('should extract contextual strings localized using $pgettext from the script', () => {


### PR DESCRIPTION
### Problem

Typescript parsing will fail if modern features (like optional chaining: `const address = user?.address`) are used.

### Fix

Enable `buntis`' `next` parsing option. As there are no issues with backwards compatibility it can be enabled by default.