### PR TITLE
replace vue compiler for vue 3 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -608,7 +608,7 @@
     },
     "@babel/parser": {
       "version": "7.7.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
+      "resolved": "https://npm.polydev.blue/@babel%2fparser/-/parser-7.7.5.tgz",
       "integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
       "dev": true
     },
@@ -1122,21 +1122,97 @@
       "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
       "dev": true
     },
-    "@vue/component-compiler-utils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-2.6.0.tgz",
-      "integrity": "sha512-IHjxt7LsOFYc0DkTncB7OXJL7UzwOLPPQCfEUNyxL2qt+tF12THV+EO33O1G2Uk4feMSWua3iD39Itszx0f0bw==",
+    "@vue/compiler-core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.0.tgz",
+      "integrity": "sha512-XqPC7vdv4rFE77S71oCHmT1K4Ks3WE2Gi6Lr4B5wn0Idmp+NyQQBUHsCNieMDRiEpgtJrw+yOHslrsV0AfAsfQ==",
       "requires": {
-        "consolidate": "^0.15.1",
-        "hash-sum": "^1.0.2",
-        "lru-cache": "^4.1.2",
-        "merge-source-map": "^1.1.0",
-        "postcss": "^7.0.14",
-        "postcss-selector-parser": "^5.0.0",
-        "prettier": "1.16.3",
-        "source-map": "~0.6.1",
-        "vue-template-es2015-compiler": "^1.9.0"
+        "@babel/parser": "^7.11.5",
+        "@babel/types": "^7.11.5",
+        "@vue/shared": "3.0.0",
+        "estree-walker": "^2.0.1",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "@babel/parser": {
+          "version": "7.11.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+          "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q=="
+        },
+        "@babel/types": {
+          "version": "7.11.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+          "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
+    },
+    "@vue/compiler-dom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.0.0.tgz",
+      "integrity": "sha512-ukDEGOP8P7lCPyStuM3F2iD5w2QPgUu2xwCW2XNeqPjFKIlR2xMsWjy4raI/cLjN6W16GtlMFaZdK8tLj5PRog==",
+      "requires": {
+        "@vue/compiler-core": "3.0.0",
+        "@vue/shared": "3.0.0"
+      }
+    },
+    "@vue/compiler-sfc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.0.0.tgz",
+      "integrity": "sha512-1Bn4L5jNRm6tlb79YwqYUGGe+Yc9PRoRSJi67NJX6icdhf84+tRMtESbx1zCLL9QixQXu2+7aLkXHxvh4RpqAA==",
+      "requires": {
+        "@babel/parser": "^7.11.5",
+        "@babel/types": "^7.11.5",
+        "@vue/compiler-core": "3.0.0",
+        "@vue/compiler-dom": "3.0.0",
+        "@vue/compiler-ssr": "3.0.0",
+        "@vue/shared": "3.0.0",
+        "consolidate": "^0.16.0",
+        "estree-walker": "^2.0.1",
+        "hash-sum": "^2.0.0",
+        "lru-cache": "^5.1.1",
+        "magic-string": "^0.25.7",
+        "merge-source-map": "^1.1.0",
+        "postcss": "^7.0.32",
+        "postcss-modules": "^3.2.2",
+        "postcss-selector-parser": "^6.0.2",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "@babel/parser": {
+          "version": "7.11.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+          "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q=="
+        },
+        "@babel/types": {
+          "version": "7.11.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+          "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@vue/compiler-ssr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.0.0.tgz",
+      "integrity": "sha512-Er41F9ZFyKB3YnNbE6JSTIGCVWve3NAQimgDOk4uP42OnckxBYKGBTutDeFNeqUZBMu/9vRHYrxlGFC9Z5jBVQ==",
+      "requires": {
+        "@vue/compiler-dom": "3.0.0",
+        "@vue/shared": "3.0.0"
+      }
+    },
+    "@vue/shared": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.0.tgz",
+      "integrity": "sha512-4XWL/avABGxU2E2ZF1eZq3Tj7fvksCMssDZUHOykBIMmh5d+KcAnQMC5XHMhtnA0NAvktYsA2YpdsVwVmhWzvA=="
     },
     "abab": {
       "version": "2.0.3",
@@ -1618,6 +1694,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+    },
     "bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -1629,9 +1710,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw=="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "boolbase": {
       "version": "1.0.0",
@@ -1994,11 +2075,11 @@
       "optional": true
     },
     "consolidate": {
-      "version": "0.15.1",
-      "resolved": "https://npm.polydev.blue/consolidate/-/consolidate-0.15.1.tgz",
-      "integrity": "sha512-DW46nrsMJgy9kqAbPt5rKaCr7uFtpo4mSUvLHIUbJEjm0vo+aY5QLwBUq3FK4tRnJr/X0Psc0C4jf/h+HtXSMw==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.16.0.tgz",
+      "integrity": "sha512-Nhl1wzCslqXYTJVDyJCu3ODohy9OfBMB5uD2BiBTzd7w+QY0lBzafkR8y8755yMYHAaMD4NuzbAw03/xzfw+eQ==",
       "requires": {
-        "bluebird": "^3.1.1"
+        "bluebird": "^3.7.2"
       }
     },
     "constantinople": {
@@ -2073,9 +2154,9 @@
       "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
     },
     "cssesc": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
-      "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
     },
     "cssom": {
       "version": "0.3.8",
@@ -2124,11 +2205,6 @@
           }
         }
       }
-    },
-    "de-indent": {
-      "version": "1.0.2",
-      "resolved": "https://npm.polydev.blue/de-indent/-/de-indent-1.0.2.tgz",
-      "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0="
     },
     "debug": {
       "version": "4.1.1",
@@ -2313,6 +2389,11 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
+    },
+    "emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -3034,6 +3115,14 @@
         }
       }
     },
+    "generic-names": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-2.0.1.tgz",
+      "integrity": "sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==",
+      "requires": {
+        "loader-utils": "^1.1.0"
+      }
+    },
     "gensync": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
@@ -3174,14 +3263,9 @@
       }
     },
     "hash-sum": {
-      "version": "1.0.2",
-      "resolved": "https://npm.polydev.blue/hash-sum/-/hash-sum-1.0.2.tgz",
-      "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ="
-    },
-    "he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+      "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg=="
     },
     "hosted-git-info": {
       "version": "2.8.5",
@@ -3266,6 +3350,19 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "icss-replace-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
+    },
+    "icss-utils": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
+      "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
+      "requires": {
+        "postcss": "^7.0.14"
+      }
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -3309,7 +3406,7 @@
     },
     "indexes-of": {
       "version": "1.0.1",
-      "resolved": "https://npm.polydev.blue/indexes-of/-/indexes-of-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
     },
     "inflight": {
@@ -4269,6 +4366,26 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "loader-utils": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "requires": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        }
+      }
+    },
     "locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -4283,6 +4400,11 @@
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -4305,12 +4427,19 @@
       }
     },
     "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "yallist": "^3.0.2"
+      }
+    },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "make-dir": {
@@ -4357,7 +4486,7 @@
     },
     "merge-source-map": {
       "version": "1.1.0",
-      "resolved": "https://npm.polydev.blue/merge-source-map/-/merge-source-map-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
       "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
       "requires": {
         "source-map": "^0.6.1"
@@ -5009,35 +5138,89 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-      "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+      "version": "7.0.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
+      "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
         "supports-color": "^6.1.0"
       }
     },
-    "postcss-selector-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
-      "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+    "postcss-modules": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-3.2.2.tgz",
+      "integrity": "sha512-JQ8IAqHELxC0N6tyCg2UF40pACY5oiL6UpiqqcIFRWqgDYO8B0jnxzoQ0EOpPrWXvcpu6BSbQU/3vSiq7w8Nhw==",
       "requires": {
-        "cssesc": "^2.0.0",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
+        "generic-names": "^2.0.1",
+        "icss-replace-symbols": "^1.1.0",
+        "lodash.camelcase": "^4.3.0",
+        "postcss": "^7.0.32",
+        "postcss-modules-extract-imports": "^2.0.0",
+        "postcss-modules-local-by-default": "^3.0.2",
+        "postcss-modules-scope": "^2.2.0",
+        "postcss-modules-values": "^3.0.0",
+        "string-hash": "^1.1.1"
       }
+    },
+    "postcss-modules-extract-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+      "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
+      "requires": {
+        "postcss": "^7.0.5"
+      }
+    },
+    "postcss-modules-local-by-default": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz",
+      "integrity": "sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==",
+      "requires": {
+        "icss-utils": "^4.1.1",
+        "postcss": "^7.0.32",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-modules-scope": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz",
+      "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
+      "requires": {
+        "postcss": "^7.0.6",
+        "postcss-selector-parser": "^6.0.0"
+      }
+    },
+    "postcss-modules-values": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
+      "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
+      "requires": {
+        "icss-utils": "^4.0.0",
+        "postcss": "^7.0.6"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
+      "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
+      "requires": {
+        "cssesc": "^3.0.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1",
+        "util-deprecate": "^1.0.2"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
     },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://npm.polydev.blue/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
-    },
-    "prettier": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.3.tgz",
-      "integrity": "sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw=="
     },
     "pretty-format": {
       "version": "24.9.0",
@@ -5087,11 +5270,6 @@
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.3"
       }
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://npm.polydev.blue/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
       "version": "1.6.0",
@@ -5829,6 +6007,11 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+    },
     "spdx-correct": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
@@ -5934,6 +6117,11 @@
       "requires": {
         "stubs": "^3.0.0"
       }
+    },
+    "string-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
     },
     "string-length": {
       "version": "2.0.0",
@@ -6322,7 +6510,7 @@
     },
     "uniq": {
       "version": "1.0.1",
-      "resolved": "https://npm.polydev.blue/uniq/-/uniq-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "unset-value": {
@@ -6443,20 +6631,6 @@
       "version": "2.0.1",
       "resolved": "https://npm.polydev.blue/void-elements/-/void-elements-2.0.1.tgz",
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
-    },
-    "vue-template-compiler": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.10.tgz",
-      "integrity": "sha512-jVZkw4/I/HT5ZMvRnhv78okGusqe0+qH2A0Em0Cp8aq78+NK9TII263CDVz2QXZsIT+yyV/gZc/j/vlwa+Epyg==",
-      "requires": {
-        "de-indent": "^1.0.2",
-        "he": "^1.1.0"
-      }
-    },
-    "vue-template-es2015-compiler": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
-      "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw=="
     },
     "w3c-hr-time": {
       "version": "1.0.1",
@@ -6661,9 +6835,9 @@
       "dev": true
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://npm.polydev.blue/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yargs": {
       "version": "13.3.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.11.5",
-    "@vue/component-compiler-utils": "^2.6.0",
+    "@vue/compiler-sfc": "^3.0.0",
     "acorn": "^6.4.1",
     "acorn-stage3": "^2.0.0",
     "acorn-walk": "^6.2.0",
@@ -43,8 +43,7 @@
     "flow-remove-types": "^1.2.3",
     "minimist": "^1.2.5",
     "pofile": "^1.1.0",
-    "pug": "^2.0.4",
-    "vue-template-compiler": "^2.6.10"
+    "pug": "^2.0.4"
   },
   "files": [
     "src"

--- a/src/extract.js
+++ b/src/extract.js
@@ -60,8 +60,8 @@ function preprocessScript(data, type) {
     if (vueFile.script) {
       contents.push({
         content: vueFile.script.content.trim(),
-        lang: vueFile.script.lang || 'js'
-      })
+        lang: vueFile.script.lang || 'js',
+      });
     }
 
     if (vueFile.template) {
@@ -69,14 +69,14 @@ function preprocessScript(data, type) {
 
       contents.push({
         content: vueTemplate.code,
-        lang: 'js'
-      })
+        lang: 'js',
+      });
     }
   } else {
     contents.push({
       content: data || '',
-      lang: type
-    })
+      lang: type,
+    });
   }
 
   return contents;
@@ -265,19 +265,19 @@ exports.Extractor = class Extractor {
     ];
   }
 
-  extract(filename, ext, filecontent) {
-    const templateData = preprocessTemplate(filecontent, ext);
+  extract(filename, ext, content) {
+    const templateData = preprocessTemplate(content, ext);
 
     if (templateData) {
-      this.parse(filename, preprocessTemplate(filecontent, ext));
+      this.parse(filename, preprocessTemplate(content, ext));
     }
 
-    preprocessScript(filecontent, ext).forEach(
-      ({content, lang}) => {
+    preprocessScript(content, ext).forEach(
+      ({content: fileContent, lang}) => {
         if (lang === 'js') {
-          this.parseJavascript(filename, content);
+          this.parseJavascript(filename, fileContent);
         } else if (lang === 'ts') {
-          this.parseTypeScript(filename, content);
+          this.parseTypeScript(filename, fileContent);
         }
       }
     );
@@ -480,6 +480,7 @@ exports.Extractor = class Extractor {
   }
 
   _getAllMatches(text, matches, re) {
+    // eslint-disable-next-line no-constant-condition
     while (true) {
       const match = re.exec(text);
       if (match === null) {
@@ -501,7 +502,7 @@ exports.Extractor = class Extractor {
     const node = $(el);
 
     if (this._hasTranslationToken(node)) {
-      const text = this._getNodeHTML(node)
+      const text = this._getNodeHTML(node);
 
       if (text.length !== 0) {
         return [new exports.NodeTranslationInfo(node, text, reference, this.options.attributes)];
@@ -566,8 +567,8 @@ exports.Extractor = class Extractor {
       .filter((x) => x !== undefined);
   }
 
-  _extractTranslationData(filename, filecontent) {
-    let content = filecontent;
+  _extractTranslationData(filename, fileContent) {
+    let content = fileContent;
     if (!Array.isArray(content)) {
       content = [content];
     }

--- a/src/extract.spec.js
+++ b/src/extract.spec.js
@@ -142,14 +142,11 @@ describe('data preprocessor', () => {
 
   it('should preprocess VueJS no script tag correctly', () => {
     const [script] = extract.preprocessScript(fixtures.VUE_COMPONENT_WITHOUT_SCRIPT_TAG, 'vue');
-    expect(script.content).toBe('var render = function() {\n'
-      + '  var _vm = this\n'
-      + '  var _h = _vm.$createElement\n'
-      + '  var _c = _vm._self._c || _h\n'
-      + '  return _c("h1", [_vm._v("Hello")])\n'
-      + '}\n'
-      + 'var staticRenderFns = []\n'
-      + 'render._withStripped = true\n');
+    expect(script.content).toBe(`import { createVNode as _createVNode, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createBlock("h1", null, "Hello"))
+}`);
   });
 
   it('should preprocess VueJS script tag in TypeScript correctly', () => {

--- a/src/extract.spec.js
+++ b/src/extract.spec.js
@@ -1,5 +1,4 @@
 const extract = require('./extract.js');
-const jsExtractor = require('./javascript-extract.js');
 const constants = require('./constants.js');
 const fixtures = require('./test-fixtures.js');
 

--- a/src/javascript-extract.js
+++ b/src/javascript-extract.js
@@ -24,12 +24,15 @@ function getGettextEntriesFromJavaScript(argTokens = []) {
   for (let i = 0; i < allTokens.length; i = i + 1) {
     let token = allTokens[i];
     for (let gettextFunc in DEFAULT_VUE_GETTEXT_FUNCTIONS) {
+      if (!DEFAULT_VUE_GETTEXT_FUNCTIONS.hasOwnProperty(gettextFunc)) {
+        continue;
+      }
+      let args = DEFAULT_VUE_GETTEXT_FUNCTIONS[gettextFunc];
       if (
         token.value === gettextFunc
         && token.type.label !== 'string' // disallows strings containing magic values: we identify FUNCTIONS
         && allTokens[i + 1].type.label === '('  // cheap check to see if it was actually a function call. It's this or a whole parsing of the location.
       ) {
-        const args = DEFAULT_VUE_GETTEXT_FUNCTIONS[gettextFunc];
         const gettextData = args.reduce(function(obj, argName, argIndex) {
           // Gets the arguments to $gettext, $pgettext, etc. from the tokens.
           // In $pgettext('context string', msgid') :

--- a/src/javascript-extract.js
+++ b/src/javascript-extract.js
@@ -24,15 +24,12 @@ function getGettextEntriesFromJavaScript(argTokens = []) {
   for (let i = 0; i < allTokens.length; i = i + 1) {
     let token = allTokens[i];
     for (let gettextFunc in DEFAULT_VUE_GETTEXT_FUNCTIONS) {
-      if (!DEFAULT_VUE_GETTEXT_FUNCTIONS.hasOwnProperty(gettextFunc)) {
-        continue;
-      }
-      let args = DEFAULT_VUE_GETTEXT_FUNCTIONS[gettextFunc];
       if (
         token.value === gettextFunc
         && token.type.label !== 'string' // disallows strings containing magic values: we identify FUNCTIONS
         && allTokens[i + 1].type.label === '('  // cheap check to see if it was actually a function call. It's this or a whole parsing of the location.
       ) {
+        const args = DEFAULT_VUE_GETTEXT_FUNCTIONS[gettextFunc];
         const gettextData = args.reduce(function(obj, argName, argIndex) {
           // Gets the arguments to $gettext, $pgettext, etc. from the tokens.
           // In $pgettext('context string', msgid') :

--- a/src/javascript-extract.spec.js
+++ b/src/javascript-extract.spec.js
@@ -21,17 +21,17 @@ describe('Javascript extractor object', () => {
       expect(firstString.msgid).toBe('Hello there!');
       expect(firstString.msgctxt).toBe(MARKER_NO_CONTEXT);
       expect(firstString.reference.file).toBe(filename);
-      expect(firstString.reference.line).toBe(10);
+      expect(firstString.reference.line).toBe(5);
 
       expect(secondString.msgid).toBe('Hello there!');
       expect(secondString.msgctxt).toBe(MARKER_NO_CONTEXT);
       expect(secondString.reference.file).toBe(filename);
-      expect(secondString.reference.line).toBe(13);
+      expect(secondString.reference.line).toBe(8);
 
       expect(thirdString.msgid).toBe('General Kenobi! You are a bold one.');
       expect(thirdString.msgctxt).toBe(MARKER_NO_CONTEXT);
       expect(thirdString.reference.file).toBe(filename);
-      expect(thirdString.reference.line).toBe(16);
+      expect(thirdString.reference.line).toBe(11);
     });
 
     it('should extract strings localized using $ngettext from the script', () => {

--- a/src/javascript-extract.spec.js
+++ b/src/javascript-extract.spec.js
@@ -181,7 +181,7 @@ describe('Javascript extractor object', () => {
       const filename = fixtures.VUE_COMPONENT_FILENAME;
       const extractedStrings = jsExtractor.extractStringsFromJavascript(
         filename,
-        fixtures.VUE_COMPONENT_EXPECTED_PROCESSED_SCRIPT_TAG,
+        fixtures.VUE_COMPONENT_EXPECTED_PROCESSED_SCRIPT_TAG
       );
 
       expect(extractedStrings.length).toBe(3);

--- a/src/test-fixtures.js
+++ b/src/test-fixtures.js
@@ -319,30 +319,25 @@ msgid "Link title"
 msgstr ""
 `;
 
-exports.VUE_COMPONENT_EXPECTED_PROCESSED_SCRIPT_TAG = `//
-//
-//
-//
-
-export default {
-    name: "greetings",
-    computed: {
-        greeting_message() {
-            return this.$gettext("Hello there!")
-        },
-        duplicated_greeting_message() {
-            return this.$gettext("Hello there!")
-        },
-        answer_message() {
-            return this.$gettext("General Kenobi! You are a bold one.")
-        }
-    },
-    methods: {
-        async getGreetingMessageAnswer() {
-            return await Promise.resolve('General Kenobi!');
-        }
-    }
-}`;
+exports.VUE_COMPONENT_EXPECTED_PROCESSED_SCRIPT_TAG = `export default {
+            name: "greetings",
+            computed: {
+                greeting_message() {
+                    return this.$gettext("Hello there!")
+                },
+                duplicated_greeting_message() {
+                    return this.$gettext("Hello there!")
+                },
+                answer_message() {
+                    return this.$gettext("General Kenobi! You are a bold one.")
+                }
+            },
+            methods: {
+                async getGreetingMessageAnswer() {
+                    return await Promise.resolve('General Kenobi!');
+                }
+            }
+        }`;
 
 exports.VUE_COMPONENT_WITH_TS_SCRIPT_TAG = `
     <template>
@@ -375,25 +370,25 @@ exports.VUE_COMPONENT_WITH_TS_SCRIPT_TAG = `
 
 exports.VUE_COMPONENT_EXPECTED_PROCESSED_TS_SCRIPT_TAG = `type Message = string;
 
-export default {
-    name: "greetings",
-    computed: {
-        greeting_message(): Message {
-            return this.$gettext("Hello there!")
-        },
-        duplicated_greeting_message(): Message {
-            return this.$gettext("Hello there!")
-        },
-        answer_message(): Message {
-            return this.$gettext("General Kenobi! You are a bold one.")
-        }
-    },
-    methods: {
-        async getGreetingMessageAnswer(): Promise<Message> {
-            return await Promise.resolve('General Kenobi!');
-        }
-    }
-}`;
+        export default {
+            name: "greetings",
+            computed: {
+                greeting_message(): Message {
+                    return this.$gettext("Hello there!")
+                },
+                duplicated_greeting_message(): Message {
+                    return this.$gettext("Hello there!")
+                },
+                answer_message(): Message {
+                    return this.$gettext("General Kenobi! You are a bold one.")
+                }
+            },
+            methods: {
+                async getGreetingMessageAnswer(): Promise<Message> {
+                    return await Promise.resolve('General Kenobi!');
+                }
+            }
+        }`;
 
 exports.VUE_COMPONENT_WITH_FLOW_SCRIPT_TAG = `
     <template>
@@ -425,33 +420,28 @@ exports.VUE_COMPONENT_WITH_FLOW_SCRIPT_TAG = `
      </script>
 `;
 
-exports.VUE_COMPONENT_EXPECTED_PROCESSED_FLOW_SCRIPT_TAG = `//
-//
-//
-//
+exports.VUE_COMPONENT_EXPECTED_PROCESSED_FLOW_SCRIPT_TAG = `// @flow
+        type Message = string;
 
-// @flow
-type Message = string;
-
-export default {
-    name: "greetings",
-    computed: {
-        greeting_message(): Message {
-            return this.$gettext("Hello there!")
-        },
-        duplicated_greeting_message(): Message {
-            return this.$gettext("Hello there!")
-        },
-        answer_message(): Message {
-            return this.$gettext("General Kenobi! You are a bold one.")
-        }
-    },
-    methods: {
-        async getGreetingMessageAnswer(): Promise<Message> {
-            return await Promise.resolve('General Kenobi!');
-        }
-    }
-}`;
+        export default {
+            name: "greetings",
+            computed: {
+                greeting_message(): Message {
+                    return this.$gettext("Hello there!")
+                },
+                duplicated_greeting_message(): Message {
+                    return this.$gettext("Hello there!")
+                },
+                answer_message(): Message {
+                    return this.$gettext("General Kenobi! You are a bold one.")
+                }
+            },
+            methods: {
+                async getGreetingMessageAnswer(): Promise<Message> {
+                    return await Promise.resolve('General Kenobi!');
+                }
+            }
+        }`;
 
 exports.SCRIPT_WITH_TEMPLATE_LITERALS = `
 export default {


### PR DESCRIPTION
I replaced the old `vue-template-compiler` with the new vue 3 `@vue/compiler-sfc` to prevent version mismatch errors when using this package with vue 3.

(also cleaned up eslint errors)

I'm not sure how you want to handle dependencies/releases. `compiler-sfc` is on `3.0.0-rc.5`, if you accept the change maybe this should be a `next` version until there's a stable `3.0.0` release.