### PR TITLE
fix #93

### DIFF
--- a/src/extract.js
+++ b/src/extract.js
@@ -83,7 +83,7 @@ function preprocessScript(data, type) {
 }
 
 function preprocessTemplate(data, type = 'html') {
-  let templateData = null;
+  let templateData = data || '';
 
   if (data) {
     if (type === 'jade' || type === 'pug') {

--- a/src/extract.spec.js
+++ b/src/extract.spec.js
@@ -111,6 +111,12 @@ describe('Extractor object', () => {
     extractor.extract(fixtures.VUE_COMPONENT_FILENAME, 'vue', fixtures.VUE_COMPONENT_WITH_GETTEXT_IN_TEMPLATE);
     expect(extractor.toString()).toEqual(fixtures.POT_OUTPUT_VUE_COMPONENT_WITH_GETTEXT_IN_TEMPLATE);
   });
+
+  it('should output a correct POT file for vue component extracted from javascript', ()=> {
+    const extractor = new extract.Extractor({attributes: ['v-translate']});
+    extractor.extract('component.js', 'js', fixtures.VUE_COMPONENT_FROM_JAVASCRIPT);
+    expect(extractor.toString()).toEqual(fixtures.POT_OUTPUT_VUE_COMPONENT_FROM_JAVASCRIPT);
+  });
 });
 
 

--- a/src/test-fixtures.js
+++ b/src/test-fixtures.js
@@ -299,6 +299,7 @@ exports.VUE_COMPONENT_WITH_GETTEXT_IN_TEMPLATE = `
     }
     </script>
 `;
+
 exports.POT_OUTPUT_VUE_COMPONENT_WITH_GETTEXT_IN_TEMPLATE = `msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=utf-8\\n"
@@ -933,6 +934,32 @@ msgid_plural "%{ n } Homes"
 msgstr[0] ""
 msgstr[1] ""
 `;
+
+
+
+exports.VUE_COMPONENT_FROM_JAVASCRIPT = `
+import Vue from 'vue'
+
+const TestComponent2 = Vue.component('TestComponent2', {
+  template: \`
+    <h1 v-translate>Test String 2</h1>
+  \`
+})
+
+export default TestComponent2
+`;
+
+exports.POT_OUTPUT_VUE_COMPONENT_FROM_JAVASCRIPT = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"Generated-By: easygettext\\n"
+"Project-Id-Version: \\n"
+
+#: component.js
+msgid "Test String 2"
+msgstr ""
+`
 
 exports.SCRIPT_GETTEXT_SEQUENCE_FILENAME = 'gettext_sequence.vue';
 exports.SCRIPT_GETTEXT_SEQUENCE = `


### PR DESCRIPTION
I thought the issue #93 was caused by something more complicated than a single line. But I ran a test and it appears the extraction only failed because the function `preprocessTemplate` returned `null` instead of the `data` attribute (if `type` was neither jade, pug, vue nor html).

I wrote a test with the component provided in the issue #93 and changed the `preprocessTemplate` function to always return data.