### PR TITLE
Use and add add jsParser property to extractor.extract in cli

### DIFF
--- a/src/extract-cli.js
+++ b/src/extract-cli.js
@@ -69,22 +69,7 @@ files.forEach(function(filename) {
   console.log(`[${PROGRAM_NAME}] extracting: '${filename}'`);
   try {
     let data = fs.readFileSync(file, {encoding: 'utf-8'}).toString();
-    extractor.parse(file, extract.preprocessTemplate(data, ext));
-
-    let lang = 'js';
-    if (ext === 'vue') {
-      const script = extract.preprocessScript(data, ext);
-      if (script) {
-        data = script.content;
-        lang = script.lang;
-      } else {
-        lang = null;
-      }
-    }
-
-    if (lang === 'js') {
-      extractor.parseJavascript(file, data, jsParser);
-    }
+    extractor.extract(file, ext, data, jsParser)
   } catch (e) {
     console.error(`[${PROGRAM_NAME}] could not read: '${filename}' using ${jsParser === 'auto' ? 'acorn' : jsParser} as parser`);
     console.trace(e);

--- a/src/extract-cli.spec.js
+++ b/src/extract-cli.spec.js
@@ -1,0 +1,24 @@
+/**
+ * Functional Testing of the Extract CLI
+ *
+ * Pay attention when adding new tests:
+ * - Jest runs the tests in parallel by default
+ * - The tests are not platform-independent
+ * - There should NOT be another test accessing your "test fixture file" in the same time
+ * - Try to pipe the data from memory rather than using temporary files
+ */
+const fixtures = require('./test-fixtures.js');
+const fs = require('fs');
+const util = require('util');
+
+const exec = util.promisify(require('child_process').exec);
+
+describe('Command Line Usage', () => {
+  it('should output a correct POT file for vue component with $gettext used in template and data', async() => {
+    // Jest runs the tests in parallel by default.
+    const path = `/tmp/TestComponent_${(new Date()).getTime()}.vue`;
+    fs.writeFileSync(path, fixtures.VUE_COMPONENT_WITH_GETTEXT_IN_TEXT_AND_DATA);
+    const {stdout} = await exec(`node ./src/extract-cli.js --attribute v-translate ${path}`);
+    expect(stdout).toEqual(fixtures.CLI_OUTPUT_VUE_COMPONENT_WITH_GETTEXT_IN_TEXT_AND_DATA.replace(/{path}/g, path));
+  });
+});

--- a/src/extract.js
+++ b/src/extract.js
@@ -265,7 +265,7 @@ exports.Extractor = class Extractor {
     ];
   }
 
-  extract(filename, ext, content) {
+  extract(filename, ext, content, jsParser = 'auto') {
     const templateData = preprocessTemplate(content, ext);
 
     if (templateData) {
@@ -275,7 +275,7 @@ exports.Extractor = class Extractor {
     preprocessScript(content, ext).forEach(
       ({content: fileContent, lang}) => {
         if (lang === 'js') {
-          this.parseJavascript(filename, fileContent);
+          this.parseJavascript(filename, fileContent, jsParser);
         } else if (lang === 'ts') {
           this.parseTypeScript(filename, fileContent);
         }

--- a/src/extract.spec.js
+++ b/src/extract.spec.js
@@ -112,6 +112,12 @@ describe('Extractor object', () => {
     expect(extractor.toString()).toEqual(fixtures.POT_OUTPUT_VUE_COMPONENT_WITH_GETTEXT_IN_TEMPLATE);
   });
 
+  it('should output a correct POT file for vue component with $gettext used in template and data', () => {
+    const extractor = new extract.Extractor({attributes: ['v-translate']});
+    extractor.extract(fixtures.VUE_COMPONENT_FILENAME, 'vue', fixtures.VUE_COMPONENT_WITH_GETTEXT_IN_TEXT_AND_DATA);
+    expect(extractor.toString()).toEqual(fixtures.POT_OUTPUT_VUE_COMPONENT_WITH_GETTEXT_IN_TEXT_AND_DATA);
+  })
+
   it('should output a correct POT file for vue component extracted from javascript', ()=> {
     const extractor = new extract.Extractor({attributes: ['v-translate']});
     extractor.extract('component.js', 'js', fixtures.VUE_COMPONENT_FROM_JAVASCRIPT);

--- a/src/test-fixtures.js
+++ b/src/test-fixtures.js
@@ -320,6 +320,61 @@ msgid "Link title"
 msgstr ""
 `;
 
+exports.VUE_COMPONENT_WITH_GETTEXT_IN_TEXT_AND_DATA = `
+<template>
+  <div>
+    <h1 v-translate>Test String 1</h1>
+    <h2>{{ testString }}</h2>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'TestComponent1',
+  data: () => ({
+    testString: this.$gettext('Test String 3')
+  })
+}
+</script>
+
+<style scoped>
+</style>
+`;
+
+exports.POT_OUTPUT_VUE_COMPONENT_WITH_GETTEXT_IN_TEXT_AND_DATA = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"Generated-By: easygettext\\n"
+"Project-Id-Version: \\n"
+
+#: GreetingsComponent.vue
+msgid "Test String 1"
+msgstr ""
+
+#: GreetingsComponent.vue
+msgid "Test String 3"
+msgstr ""
+`
+
+exports.CLI_OUTPUT_VUE_COMPONENT_WITH_GETTEXT_IN_TEXT_AND_DATA = `[easygettext] extracting: '{path}'
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"Generated-By: easygettext\\n"
+"Project-Id-Version: \\n"
+
+#: {path}:2
+msgid "Test String 1"
+msgstr ""
+
+#: {path}:4
+msgid "Test String 3"
+msgstr ""
+
+`
+
 exports.VUE_COMPONENT_EXPECTED_PROCESSED_SCRIPT_TAG = `export default {
             name: "greetings",
             computed: {


### PR DESCRIPTION
The function `extractor.extract` is being used in all unit tests, but the extract-CLI has its own logic without a test coverage (see issue #93). The custom logic in the extract-CLI was added about ten months ago to add babel parser support.

https://github.com/Polyconseil/easygettext/commit/b612f643b7a45f5dd5b9c69b1face0831973ea61#diff-d02db1886300be48b7371dc7819f1634R72

To regain test coverage I'd like to replace the custom logic in the extract-CLI with the `extractor.extract` function. To continue the babel parser support, I'd like to also add the jsParser property to the `extractor.extract` function.