### PR TITLE
extractor: Support pug includes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2079,13 +2079,19 @@
         "@babel/types": "^7.9.6"
       },
       "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel%2fhelper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+          "optional": true
+        },
         "@babel/types": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-          "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel%2ftypes/-/types-7.13.0.tgz",
+          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
           "optional": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
+            "@babel/helper-validator-identifier": "^7.12.11",
             "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           }
@@ -2239,6 +2245,16 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
+      }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "optional": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
       }
     },
     "callsites": {
@@ -3509,6 +3525,12 @@
       "dev": true,
       "optional": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "optional": true
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -3534,6 +3556,17 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "optional": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -3622,15 +3655,24 @@
         "har-schema": "^2.0.0"
       }
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "optional": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://npm.polydev.blue/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://npm.polydev.blue/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "version": "1.0.2",
+      "resolved": "https://npm.polydev.blue/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
       "optional": true
     },
     "has-value": {
@@ -4013,11 +4055,12 @@
       "optional": true
     },
     "is-regex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
       "optional": true,
       "requires": {
+        "call-bind": "^1.0.2",
         "has-symbols": "^1.0.1"
       }
     },
@@ -7190,18 +7233,18 @@
       "dev": true
     },
     "pug": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.0.tgz",
-      "integrity": "sha512-inmsJyFBSHZaiGLaguoFgJGViX0If6AcfcElimvwj9perqjDpUpw79UIEDZbWFmoGVidh08aoE+e8tVkjVJPCw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
+      "integrity": "sha512-bp0I/hiK1D1vChHh6EfDxtndHji55XP/ZJKwsRqrz6lRia6ZC2OZbdAymlxdVFwd1L70ebrVJw4/eZ79skrIaw==",
       "optional": true,
       "requires": {
-        "pug-code-gen": "^3.0.0",
+        "pug-code-gen": "^3.0.2",
         "pug-filters": "^4.0.0",
-        "pug-lexer": "^5.0.0",
+        "pug-lexer": "^5.0.1",
         "pug-linker": "^4.0.0",
         "pug-load": "^3.0.0",
         "pug-parser": "^6.0.0",
-        "pug-runtime": "^3.0.0",
+        "pug-runtime": "^3.0.1",
         "pug-strip-comments": "^2.0.0"
       }
     },
@@ -7217,9 +7260,9 @@
       }
     },
     "pug-code-gen": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.1.tgz",
-      "integrity": "sha512-xJIGvmXTQlkJllq6hqxxjRWcay2F9CU69TuAuiVZgHK0afOhG5txrQOcZyaPHBvSWCU/QQOqEp5XCH94rRZpBQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
+      "integrity": "sha512-nJMhW16MbiGRiyR4miDTQMRWDgKplnHyeLvioEJYbk1RsPI3FuA3saEP8uwnTb2nTJEKBU90NFVWJBk4OU5qyg==",
       "optional": true,
       "requires": {
         "constantinople": "^4.0.1",
@@ -7252,9 +7295,9 @@
       }
     },
     "pug-lexer": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.0.tgz",
-      "integrity": "sha512-52xMk8nNpuyQ/M2wjZBN5gXQLIylaGkAoTk5Y1pBhVqaopaoj8Z0iVzpbFZAqitL4RHNVDZRnJDsqEYe99Ti0A==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.1.tgz",
+      "integrity": "sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==",
       "optional": true,
       "requires": {
         "character-parser": "^2.2.0",
@@ -7293,9 +7336,9 @@
       }
     },
     "pug-runtime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-3.0.0.tgz",
-      "integrity": "sha512-GoEPcmQNnaTsePEdVA05bDpY+Op5VLHKayg08AQiqJBWU/yIaywEYv7TetC5dEQS3fzBBoyb2InDcZEg3mPTIA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-3.0.1.tgz",
+      "integrity": "sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg==",
       "optional": true
     },
     "pug-strip-comments": {
@@ -8657,19 +8700,25 @@
         "babel-walk": "3.0.0-canary-5"
       },
       "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel%2fhelper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+          "optional": true
+        },
         "@babel/parser": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-          "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+          "version": "7.13.9",
+          "resolved": "https://registry.npmjs.org/@babel%2fparser/-/parser-7.13.9.tgz",
+          "integrity": "sha512-nEUfRiARCcaVo3ny3ZQjURjHQZUo/JkEw7rLlSZy/psWGnvwXFtPcr6jb7Yb41DVW5LTe6KRq9LGleRNsg1Frw==",
           "optional": true
         },
         "@babel/types": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-          "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel%2ftypes/-/types-7.13.0.tgz",
+          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
           "optional": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
+            "@babel/helper-validator-identifier": "^7.12.11",
             "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "optionalDependencies": {
     "@vue/compiler-sfc": "^3.0.0",
-    "pug": "^3.0.0"
+    "pug": "^3.0.2"
   },
   "files": [
     "src"

--- a/src/extract.js
+++ b/src/extract.js
@@ -81,14 +81,14 @@ function preprocessScript(data, type) {
   return contents;
 }
 
-function preprocessTemplate(data, type = 'html') {
+function preprocessTemplate(data, type = 'html', filename = null) {
   let templateData = data || '';
 
   if (data) {
     if (type === 'jade' || type === 'pug') {
       const pug = require('pug');
       templateData = pug.render(data, {
-        filename: 'source.html',
+        filename: filename,
         pretty: true,
         require: () => {
         },
@@ -104,7 +104,7 @@ function preprocessTemplate(data, type = 'html') {
         let lang = $(this).attr('lang');
 
         if (lang) {
-          return preprocessTemplate($(this).html(), lang);
+          return preprocessTemplate($(this).html(), lang, filename);
         }
 
         return $(this).html().trim();
@@ -266,10 +266,10 @@ exports.Extractor = class Extractor {
   }
 
   extract(filename, ext, content, jsParser = 'auto') {
-    const templateData = preprocessTemplate(content, ext);
+    const templateData = preprocessTemplate(content, ext, filename);
 
     if (templateData) {
-      this.parse(filename, preprocessTemplate(content, ext));
+      this.parse(filename, templateData);
     }
 
     preprocessScript(content, ext).forEach(

--- a/src/extract.spec.js
+++ b/src/extract.spec.js
@@ -1,6 +1,9 @@
 const extract = require('./extract.js');
 const constants = require('./constants.js');
 const fixtures = require('./test-fixtures.js');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 
 
 describe('Extractor object', () => {
@@ -168,6 +171,16 @@ export function render(_ctx, _cache) {
   it('should preprocess VueJS script tag with Flow', () => {
     const [script] = extract.preprocessScript(fixtures.VUE_COMPONENT_WITH_FLOW_SCRIPT_TAG, 'vue');
     expect(script.content).toEqual(fixtures.VUE_COMPONENT_EXPECTED_PROCESSED_FLOW_SCRIPT_TAG);
+  });
+  it('should preprocess pug including another pug file correctly', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'easygettext-test-pug'));
+    const pugFileName = path.join(tmpDir, fixtures.PUG_FILENAME);
+    const pugIncludedFileName = path.join(tmpDir, fixtures.PUG_INCLUDED_FILENAME);
+    fs.mkdirSync(path.dirname(pugIncludedFileName));
+    fs.writeFileSync(pugIncludedFileName, fixtures.PUG_COMMON_FOOTER);
+
+    const preprocessed = extract.preprocessTemplate(fixtures.PUG_WITH_INCLUDE, 'pug', pugFileName);
+    expect(preprocessed).toEqual(fixtures.PUG_EXPECTED_PROCESSED_PUG_WITH_INCLUDE);
   });
 });
 

--- a/src/test-fixtures.js
+++ b/src/test-fixtures.js
@@ -2,6 +2,8 @@ exports.FILENAME_0             = 'foo.htm';
 exports.FILENAME_1             = 'bar.htm';
 exports.FILENAME_2             = 'baz.vue';
 exports.VUE_COMPONENT_FILENAME = 'GreetingsComponent.vue';
+exports.PUG_FILENAME           = 'index.pug';
+exports.PUG_INCLUDED_FILENAME  = 'common/footer.pug';
 
 
 exports.HTML0_CTX0 = `
@@ -1014,6 +1016,19 @@ msgstr ""
 msgid "Test String 2"
 msgstr ""
 `;
+
+exports.PUG_WITH_INCLUDE = `
+h1 hello
+include common/footer
+`;
+exports.PUG_COMMON_FOOTER = `
+footer
+  p Copyright E CORP
+`;
+exports.PUG_EXPECTED_PROCESSED_PUG_WITH_INCLUDE = `<h1>hello</h1>
+<footer>
+  <p>Copyright E CORP</p>
+</footer>`;
 
 exports.SCRIPT_GETTEXT_SEQUENCE_FILENAME = 'gettext_sequence.vue';
 exports.SCRIPT_GETTEXT_SEQUENCE = `


### PR DESCRIPTION
gettext-extract fails to extract translations from pug files that include relative paths to other pug files.