### PR TITLE
Replace buntis with typescript-estree

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "@types/jest": "^26.0.14",
     "codecov": "^3.8.0",
     "eslint": "^7.10.0",
-    "jest": "^26.5.2"
+    "jest": "^26.5.2",
+    "typescript": "^4.2.0"
   },
   "engines": {
     "node": ">=8"
@@ -36,7 +37,7 @@
     "acorn": "^7.4.0",
     "acorn-stage3": "^4.0.0",
     "acorn-walk": "^8.0.0",
-    "buntis": "0.2.1",
+    "@typescript-eslint/typescript-estree": "^4.0.0",
     "cheerio": "^1.0.0-rc.3",
     "estree-walker": "^2.0.1",
     "flow-remove-types": "^2.135.0",

--- a/src/typescript-extract.js
+++ b/src/typescript-extract.js
@@ -1,5 +1,5 @@
 const {walk} = require('estree-walker');
-const {parseTSScript} = require('buntis');
+const {parse} = require('@typescript-eslint/typescript-estree');
 const extractUtils = require('./extract-utils.js');
 
 const {DEFAULT_VUE_GETTEXT_FUNCTIONS} = require('./constants.js');
@@ -41,8 +41,9 @@ function getTranslationObject(node, gettextFunctionName, filename) {
 }
 
 function getGettextEntriesFromTypeScript(script, filename) {
-  let translationEntries = [];
-  walk(parseTSScript(script, {loc: true, next: true}), {
+  const translationEntries = [];
+  const ast = parse(script, { loc: true, range: true });
+  walk(ast, {
     enter: function(node) {
       if (node.type && node.type === 'CallExpression' && node.callee) {
         if (DEFAULT_VUE_GETTEXT_FUNCTIONS_KEYS.includes(node.callee.name)) {


### PR DESCRIPTION
The buntis git repo has been deleted by upstream, so we shouldn't rely on it. For future historians: See https://github.com/meriyah/meriyah/issues/48 

If you want reliable typescript parsing then we have typescript-estree nowadays, which is used by eslint and prettier. See https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/typescript-estree for more details.