### PR TITLE
Added $tc to the list of default gettext functions in Vue

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -14,6 +14,7 @@ exports.DEFAULT_FILTERS = [
 exports.DEFAULT_VUE_GETTEXT_FUNCTIONS = {
   '_': ['msgid'],
   '$t': ['msgid'],
+  '$tc': ['msgid'],
   '$gettext': ['msgid'],
   '$ngettext': ['msgid', 'plural', null],
   '$pgettext': ['msgctxt', 'msgid'],


### PR DESCRIPTION
$tc is used by "vue-i18n". See: https://vue-i18n.intlify.dev/guide/essentials/pluralization.html