### PR TITLE
feat: Vue 2 <script setup> support

### DIFF
--- a/src/extract.js
+++ b/src/extract.js
@@ -63,6 +63,14 @@ function preprocessScript(data, type) {
       });
     }
 
+    // Vue 2 <script setup> support
+    if (vueFile.scriptSetup) {
+      contents.push({
+        content: vueFile.scriptSetup.content.trim(),
+        lang: vueFile.scriptSetup.lang || 'js',
+      });
+    }
+
     if (vueFile.template) {
       const vueTemplate = compileTemplate({source: vueFile.template.content});
 


### PR DESCRIPTION
Since the current implementation only scans for normal `script` tag we have to add support for `<script setup>` as well in order for extraction to work in such cases.